### PR TITLE
Organizes the code

### DIFF
--- a/extension/app/highlighter.js
+++ b/extension/app/highlighter.js
@@ -1,16 +1,61 @@
 /* jshint esversion: 6 */
 
-define(['../var/document', '../var/languages'], function(document, languages) {
+define(['../var/document', '../var/languages'], (document, languages) => {
     'use strict';
 
     const INTERVAL = 50; // Interval in milliseconds.
 
+    return {
+        init() {
+            insertStyles();
+            waitForRender('.diff-container').then(() => {
+                prepareLanguageClasses();
+                addCodeTagToElements('.source');
+                Prism.highlightAll();
+            });
+        }
+    };
+
+    /**
+     * Waits some intervals until a specific element is displayed.
+     * @return {Promise} Returns a promise that is fulfilled when it finds a specific element.
+     */
+    function waitForRender(selector) {
+        return new Promise(resolve => {
+            const intervalId = setInterval(() => {
+                const element = document.querySelector(selector);
+                if (!element) {
+                    return;
+                }
+
+                // If element is rendered, stop the interval and continue.
+                clearInterval(intervalId);
+                resolve();
+            }, INTERVAL);
+        });
+    }
+
+    /**
+     * Adds the necessary styles to the <head>.
+     * It shouldn't be needed, since we have the prism.css, but for some reason
+     * the styles are not being injected into the page.
+     */
+    function insertStyles() {
+        const head = document.getElementsByTagName('head')[0];
+        const style = document.createElement('style');
+        style.type = 'text/css';
+        // Prism css
+        style.innerHTML = '.token.comment,.token.prolog,.token.doctype,.token.cdata{color: slategray}.token.punctuation{color: #999}.namespace{opacity: .7}.token.property,.token.tag,.token.boolean,.token.number,.token.constant,.token.symbol,.token.deleted{color: #905}.token.selector,.token.attr-name,.token.string,.token.char,.token.builtin,.token.inserted{color: #690}.token.operator,.token.entity,.token.url,.language-css .token.string,.style .token.string{color: #a67f59;background: hsla(0, 0%, 100%, .5)}.token.atrule,.token.attr-value,.token.keyword{color: #07a}.token.function{color: #DD4A68}.token.regex,.token.important,.token.variable{color: #e90}.token.important,.token.bold{font-weight: bold}.token.italic{font-style: italic}.token.entity{cursor: help}';
+        // Custom css to fix some layout problems because of the insertion of <code> element
+        style.innerHTML += 'pre>code{border-radius:initial;display:initial;line-height:initial;margin-left:initial;overflow-y:initial;padding:initial}code,tt{background:initial;border:initial}.refract-container .deletion pre.source {background-color: #fff1f2 !important;} .refract-container .addition pre.source { background-color: #e8ffe8;}';
+        head.appendChild(style);
+    }
+
     /**
      * Adds language-xxxx definition class to div ancestor element thus Prism
      * assumes that the definition is inherited.
-     * @return {void}
      */
-    function addLanguageClass() {
+    function prepareLanguageClasses() {
         const containers = Array.from(document.getElementsByClassName('diff-container'));
         containers.forEach(container => {
             const parent = container.parentElement;
@@ -23,29 +68,14 @@ define(['../var/document', '../var/languages'], function(document, languages) {
     }
 
     /**
-     * Adds the necessary styles to the <head>.
-     * It shouldn't be needed, since we have the prism.css, but for some reason
-     * the styles are not being injected into the page.
-     * @return {void}
-     */
-    function insertStyles() {
-        const head = document.getElementsByTagName('head')[0];
-        let style = document.createElement('style');
-        style.type = 'text/css';
-        // Prism css
-        style.innerHTML = '.token.comment,.token.prolog,.token.doctype,.token.cdata{color: slategray}.token.punctuation{color: #999}.namespace{opacity: .7}.token.property,.token.tag,.token.boolean,.token.number,.token.constant,.token.symbol,.token.deleted{color: #905}.token.selector,.token.attr-name,.token.string,.token.char,.token.builtin,.token.inserted{color: #690}.token.operator,.token.entity,.token.url,.language-css .token.string,.style .token.string{color: #a67f59;background: hsla(0, 0%, 100%, .5)}.token.atrule,.token.attr-value,.token.keyword{color: #07a}.token.function{color: #DD4A68}.token.regex,.token.important,.token.variable{color: #e90}.token.important,.token.bold{font-weight: bold}.token.italic{font-style: italic}.token.entity{cursor: help}';
-        // Custom css to fix some layout problems because of the insertion of <code> element
-        style.innerHTML += 'pre>code{border-radius:initial;display:initial;line-height:initial;margin-left:initial;overflow-y:initial;padding:initial}code,tt{background:initial;border:initial}.refract-container .deletion pre.source {background-color: #fff1f2 !important;} .refract-container .addition pre.source { background-color: #e8ffe8;}';
-        head.appendChild(style);
-    }
-
-    /**
-     * Surrounds each line of code with a <code> element.
+     * Surrounds each selector (always an element with 'source' class) with a <code> element.
      * That's the way Prism expects your code to be: <pre><code>{code_here}</code></pre>
-     * @return {void}
+     * @param {string} elementsSelector The selector, eg. '.source'
+     * @return {Array} Returns a array with the created <code> elements.
      */
-    function addCodeTag() {
-        const lines = Array.from(document.getElementsByClassName('source'));
+    function addCodeTagToElements(elementsSelector) {
+        const lines = Array.from(document.querySelectorAll(elementsSelector));
+        const codeTags = [];
         let size = lines.length;
         while (size--) {
             const codeEl = document.createElement('code');
@@ -53,32 +83,8 @@ define(['../var/document', '../var/languages'], function(document, languages) {
             codeEl.innerText = line.textContent;
             line.textContent = '';
             line.appendChild(codeEl);
+            codeTags.push(codeEl);
         }
+        return codeTags;
     }
-
-    /**
-     * Wait for page render the elements (content is rendered via Ajax)
-     * and highlight the source code.
-     * @return {void}
-     */
-    function highlightWhenReady() {
-        const intervalId = setInterval(() => {
-            const container = document.getElementById('pullrequest-diff');
-            if (!container) return;
-
-            // If main container is rendered, stop the interval and continue.
-            clearInterval(intervalId);
-
-            addLanguageClass();
-            addCodeTag();
-            insertStyles();
-            Prism.highlightAll();
-        }, INTERVAL);
-    }
-
-    return {
-        run: function() {
-            highlightWhenReady();
-        }
-    };
 });

--- a/extension/app/main.js
+++ b/extension/app/main.js
@@ -1,9 +1,9 @@
 require({
-        baseUrl: chrome.extension.getURL("/"),
-        paths: { jquery: "//ajax.googleapis.com/ajax/libs/jquery/2.0.0/jquery.min" }
-    }, ["app/highlighter", "app/doubleClickWordSelection"],
-    function(highlighter, doubleClickWordSelection) {
-        highlighter.run();
+    baseUrl: chrome.extension.getURL("/"),
+    paths: {jquery: "//ajax.googleapis.com/ajax/libs/jquery/2.0.0/jquery.min"}
+}, ["app/highlighter", "app/doubleClickWordSelection"],
+    (highlighter, doubleClickWordSelection) => {
+        highlighter.init();
         doubleClickWordSelection.run();
     }
 );

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "esnext": true,
     "space": 4,
     "globals": [
-      "Prism"
+      "Prism",
+      "chrome",
+      "define"
     ]
   }
 }


### PR DESCRIPTION
Changes:

**addCodeTag**
Renamed addCodeTag to addCodeTagToElements and now it returns an array with the created `<code>` elements. This is good because when we change the code to highlight only a few elements (instead of calling `Prism.highlightAll()`) we'll already have the elements we need to pass to `Prism.highlightElement()`.

**waitForRender**:
Now it returns a promise. This makes it easier and clearer to work with async code.
Changed it to receive a selector as parameter for better reuse.
