### PR TITLE
Update manifest

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -30,7 +30,7 @@
         "vendor/jquery.highlight.js",
         "extension.js"
       ],
-      "matches": ["https://bitbucket.org/*"]
+      "matches": ["https://bitbucket.org/*", "https://bitbucket.*"]
     }
   ]
 }


### PR DESCRIPTION
The extension wasn't working for me because it only targets the hosted version of bitbucket.
So I updated manifest to also hit when you have private bitbucket on subdomain e.g. http://bitbucket.example.com
