### PR TITLE
Revert "Update manifest"

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -30,7 +30,7 @@
         "vendor/jquery.highlight.js",
         "extension.js"
       ],
-      "matches": ["https://bitbucket.org/*", "https://bitbucket.*"]
+      "matches": ["https://bitbucket.org/*"]
     }
   ]
 }


### PR DESCRIPTION
Reverts andremw/refined-bitbucket#26

I had to revert it because "https://bitbucket*" is not a valid match in extension.

https://developer.chrome.com/extensions/match_patterns

@RamonGebben we'll need to check further how to do it.
