### PR TITLE
added side-by-side view syntax highlighting

### DIFF
--- a/src/approvals/approvals.js
+++ b/src/approvals/approvals.js
@@ -6,6 +6,8 @@ module.exports = (function () {
     return {
         init() {
             const mergeButton = document.getElementById('fulfill-pullrequest');
+            if (!mergeButton) return;
+
             bindApprovalClick();
             shouldMergeBeDisabled().then(disable => {
                 mergeButton.disabled = disable;

--- a/src/approvals/approvals.js
+++ b/src/approvals/approvals.js
@@ -6,7 +6,9 @@ module.exports = (function () {
     return {
         init() {
             const mergeButton = document.getElementById('fulfill-pullrequest');
-            if (!mergeButton) return;
+            if (!mergeButton) {
+                return;
+            }
 
             bindApprovalClick();
             shouldMergeBeDisabled().then(disable => {

--- a/src/debounce.js
+++ b/src/debounce.js
@@ -1,17 +1,17 @@
 // Courtesy of http://underscorejs.org/
 module.exports = function debounce(func, wait, immediate) {
-    var timeout;
+    let timeout;
 
     return function () {
         const context = this;
         const args = arguments;
-        let later = function () {
+        const later = function () {
             timeout = null;
             if (!immediate) {
                 func.apply(context, args);
             }
         };
-        let callNow = immediate && !timeout;
+        const callNow = immediate && !timeout;
         clearTimeout(timeout);
         timeout = setTimeout(later, wait);
         if (callNow) {

--- a/src/debounce.js
+++ b/src/debounce.js
@@ -3,14 +3,19 @@ module.exports = function debounce(func, wait, immediate) {
     var timeout;
 
     return function () {
-        var context = this, args = arguments;
+        let context = this;
+        let args = arguments;
         var later = function () {
             timeout = null;
-            if (!immediate) func.apply(context, args);
+            if (!immediate) {
+                func.apply(context, args);
+            }
         };
         var callNow = immediate && !timeout;
         clearTimeout(timeout);
         timeout = setTimeout(later, wait);
-        if (callNow) func.apply(context, args);
+        if (callNow) {
+            func.apply(context, args);
+        }
     };
 };

--- a/src/debounce.js
+++ b/src/debounce.js
@@ -3,15 +3,15 @@ module.exports = function debounce(func, wait, immediate) {
     var timeout;
 
     return function () {
-        let context = this;
-        let args = arguments;
-        var later = function () {
+        const context = this;
+        const args = arguments;
+        let later = function () {
             timeout = null;
             if (!immediate) {
                 func.apply(context, args);
             }
         };
-        var callNow = immediate && !timeout;
+        let callNow = immediate && !timeout;
         clearTimeout(timeout);
         timeout = setTimeout(later, wait);
         if (callNow) {

--- a/src/debounce.js
+++ b/src/debounce.js
@@ -1,0 +1,16 @@
+// Courtesy of http://underscorejs.org/
+module.exports = function debounce(func, wait, immediate) {
+    var timeout;
+
+    return function () {
+        var context = this, args = arguments;
+        var later = function () {
+            timeout = null;
+            if (!immediate) func.apply(context, args);
+        };
+        var callNow = immediate && !timeout;
+        clearTimeout(timeout);
+        timeout = setTimeout(later, wait);
+        if (callNow) func.apply(context, args);
+    };
+};

--- a/src/events.js
+++ b/src/events.js
@@ -32,14 +32,14 @@ function bindOverviewClick() {
 }
 
 function bindSideDiffButtons() {
-    let sideBySideButtons = $('button[href*="side-by-side"]').toArray();
+    const sideBySideButtons = $('button[href*="side-by-side"]').toArray();
     sideBySideButtons.forEach(button => button.addEventListener('click', initalizeSideDiffHighlighter));
 }
 
 function initalizeSideDiffHighlighter(mouseEventArgs) {
-    let button = mouseEventArgs.currentTarget;
+    const button = mouseEventArgs.currentTarget;
     if (button.attributes.href && button.attributes.href.nodeValue) {
-        let unifiedDiffContainer = button.closest('.bb-udiff');
+        const unifiedDiffContainer = button.closest('.bb-udiff');
         if (unifiedDiffContainer) {
             pubsub.publish('highlight-side-diff', {container: unifiedDiffContainer, diffNode: button.attributes.href.nodeValue});
         }

--- a/src/events.js
+++ b/src/events.js
@@ -17,6 +17,8 @@ module.exports = (function events() {
 
     function bindEvents() {
         bindOverviewClick();
+        bindSideDiffButtons();
+
         observeCodeContainers(codeContainers);
     }
 })();
@@ -26,6 +28,21 @@ function bindOverviewClick() {
     // in the commit screen the overview tab will not exist
     if (overviewTab) {
         overviewTab.addEventListener('click', triggerHighlight);
+    }
+}
+
+function bindSideDiffButtons() {
+    var sideBySideButtons = $('button[href*="side-by-side"]').toArray();
+    sideBySideButtons.forEach((button) => button.addEventListener('click', initalizeSideDiffHighlighter));
+}
+
+function initalizeSideDiffHighlighter(mouseEventArgs) {
+    var button = mouseEventArgs.currentTarget;
+    if (button.attributes.href && button.attributes.href.nodeValue) {
+        var unifiedDiffContainer = button.closest('.bb-udiff');
+        if (unifiedDiffContainer) {
+            pubsub.publish('highlight-side-diff', { container: unifiedDiffContainer, diffNode: button.attributes.href.nodeValue });
+        }
     }
 }
 

--- a/src/events.js
+++ b/src/events.js
@@ -32,16 +32,16 @@ function bindOverviewClick() {
 }
 
 function bindSideDiffButtons() {
-    var sideBySideButtons = $('button[href*="side-by-side"]').toArray();
-    sideBySideButtons.forEach((button) => button.addEventListener('click', initalizeSideDiffHighlighter));
+    let sideBySideButtons = $('button[href*="side-by-side"]').toArray();
+    sideBySideButtons.forEach(button => button.addEventListener('click', initalizeSideDiffHighlighter));
 }
 
 function initalizeSideDiffHighlighter(mouseEventArgs) {
-    var button = mouseEventArgs.currentTarget;
+    let button = mouseEventArgs.currentTarget;
     if (button.attributes.href && button.attributes.href.nodeValue) {
-        var unifiedDiffContainer = button.closest('.bb-udiff');
+        let unifiedDiffContainer = button.closest('.bb-udiff');
         if (unifiedDiffContainer) {
-            pubsub.publish('highlight-side-diff', { container: unifiedDiffContainer, diffNode: button.attributes.href.nodeValue });
+            pubsub.publish('highlight-side-diff', {container: unifiedDiffContainer, diffNode: button.attributes.href.nodeValue});
         }
     }
 }

--- a/src/events.js
+++ b/src/events.js
@@ -32,7 +32,7 @@ function bindOverviewClick() {
 }
 
 function bindSideDiffButtons() {
-    const sideBySideButtons = $('button[href*="side-by-side"]').toArray();
+    const sideBySideButtons = Array.from(document.querySelectorAll('button[href*="side-by-side"]'));
     sideBySideButtons.forEach(button => button.addEventListener('click', initalizeSideDiffHighlighter));
 }
 

--- a/src/syntax-highlight/language-ext.js
+++ b/src/syntax-highlight/language-ext.js
@@ -2,6 +2,8 @@ module.exports = {
     '.groovy': 'language-groovy',
     '.gradle': 'language-groovy',
     '.bash': 'language-bash',
+    '.config': 'language-markup',
+    '.csproj': 'language-markup',
     '.sh': 'language-bash',
     '.jsp': 'language-java',
     '.java': 'language-java',
@@ -46,8 +48,12 @@ module.exports = {
     '.scss': 'language-scss',
     '.sbt': 'language-scala',
     '.scala': 'language-scala',
+    '.sfproj': 'language-markup',
+    '.sql': 'language-sql',
     '.swift': 'language-swift',
     '.ts': 'language-typescript',
+    '.wxs': 'language-markup',
+    '.xaml': 'language-markup',
     '.yaml': 'language-yaml',
     '.yml': 'language-yaml'
 };

--- a/src/syntax-highlight/source-handler.js
+++ b/src/syntax-highlight/source-handler.js
@@ -30,7 +30,7 @@ module.exports.getClassBasedOnExtension = function getClassBasedOnExtension(elem
     if (!fileExtension) {
         throw new Error('couldn\'t find neither data-filename nor data-path in the element');
     }
-    return languagesExtensions[fileExtension] || '';
+    return languagesExtensions[fileExtension.toLowerCase()] || '';
 };
 
 function getFilepathFromElement(element) {

--- a/src/syntax-highlight/syntax-highlight.js
+++ b/src/syntax-highlight/syntax-highlight.js
@@ -4,12 +4,14 @@
 
 const waitForRender = require('../wait-for-render');
 const pubsub = require('../pubsub');
-
+const debounce = require('../debounce');
 const sourceHandler = require('./source-handler');
 
 module.exports = (function syntaxHighlight() {
     pubsub.subscribe('highlight-all', highlightAll);
     pubsub.subscribe('highlight', highlightSome);
+    pubsub.subscribe('highlight-side-diff', highlightSideDiff);
+    pubsub.subscribe('highlight-side-diff', listenForSideDiffScroll);
 
     return {
         init() {
@@ -38,6 +40,46 @@ module.exports = (function syntaxHighlight() {
     function highlightAll() {
         Promise.all([classifyDiffContainers(), transformPreElements()])
         .then(() => Prism.highlightAll());
+    }
+
+    var debouncedSideDiffHandler;
+
+    function listenForSideDiffScroll(args) {
+        waitForRender("div.aperture-pane-scroller").then(() => {
+            var scrollers = Array.from(document.querySelectorAll("div.aperture-pane-scroller"));
+
+            if (debouncedSideDiffHandler) {
+                scrollers.forEach(scroller => {
+                    scroller.removeEventListener("scroll", debouncedSideDiffHandler);
+                });
+            }
+
+            debouncedSideDiffHandler = debounce(() => highlightSideDiff(args), 250);
+
+            scrollers.forEach(scroller => {
+                scroller.addEventListener("scroll", debouncedSideDiffHandler);
+            });
+        });
+    }
+
+    function highlightSideDiff(args) {
+        waitForRender(args.diffNode).then(() => {
+            var container = document.querySelector(args.diffNode);
+
+            var languageClass = sourceHandler.getClassBasedOnExtension(args.container) || '';
+            container.classList.add(languageClass);
+
+            waitForRender(args.diffNode + ' pre').then(() => {
+                var sourceLines = Array.from(document.querySelectorAll(args.diffNode + ' pre:not([class*=language])'));
+
+                sourceLines.forEach(line => {
+                    const codeElement = sourceHandler.getCodeElementFromPre(line);
+                    line.innerHTML = codeElement.outerHTML;
+                    line.classList.add("source");
+                    Prism.highlightElement(line);
+                });
+            });
+        });
     }
 
     function highlightSome() {

--- a/src/syntax-highlight/syntax-highlight.js
+++ b/src/syntax-highlight/syntax-highlight.js
@@ -7,6 +7,8 @@ const pubsub = require('../pubsub');
 const debounce = require('../debounce');
 const sourceHandler = require('./source-handler');
 
+let debouncedSideDiffHandler = null;
+
 module.exports = (function syntaxHighlight() {
     pubsub.subscribe('highlight-all', highlightAll);
     pubsub.subscribe('highlight', highlightSome);
@@ -42,22 +44,20 @@ module.exports = (function syntaxHighlight() {
         .then(() => Prism.highlightAll());
     }
 
-    var debouncedSideDiffHandler;
-
     function listenForSideDiffScroll(args) {
-        waitForRender("div.aperture-pane-scroller").then(() => {
-            const scrollers = Array.from(document.querySelectorAll("div.aperture-pane-scroller"));
+        waitForRender('div.aperture-pane-scroller').then(() => {
+            const scrollers = Array.from(document.querySelectorAll('div.aperture-pane-scroller'));
 
             if (debouncedSideDiffHandler) {
                 scrollers.forEach(scroller => {
-                    scroller.removeEventListener("scroll", debouncedSideDiffHandler);
+                    scroller.removeEventListener('scroll', debouncedSideDiffHandler);
                 });
             }
 
             debouncedSideDiffHandler = debounce(() => highlightSideDiff(args), 250);
 
             scrollers.forEach(scroller => {
-                scroller.addEventListener("scroll", debouncedSideDiffHandler);
+                scroller.addEventListener('scroll', debouncedSideDiffHandler);
             });
         });
     }
@@ -75,7 +75,7 @@ module.exports = (function syntaxHighlight() {
                 sourceLines.forEach(line => {
                     const codeElement = sourceHandler.getCodeElementFromPre(line);
                     line.innerHTML = codeElement.outerHTML;
-                    line.classList.add("source");
+                    line.classList.add('source');
                     Prism.highlightElement(line);
                 });
             });

--- a/src/syntax-highlight/syntax-highlight.js
+++ b/src/syntax-highlight/syntax-highlight.js
@@ -46,7 +46,7 @@ module.exports = (function syntaxHighlight() {
 
     function listenForSideDiffScroll(args) {
         waitForRender("div.aperture-pane-scroller").then(() => {
-            var scrollers = Array.from(document.querySelectorAll("div.aperture-pane-scroller"));
+            const scrollers = Array.from(document.querySelectorAll("div.aperture-pane-scroller"));
 
             if (debouncedSideDiffHandler) {
                 scrollers.forEach(scroller => {
@@ -64,13 +64,13 @@ module.exports = (function syntaxHighlight() {
 
     function highlightSideDiff(args) {
         waitForRender(args.diffNode).then(() => {
-            var container = document.querySelector(args.diffNode);
+            const container = document.querySelector(args.diffNode);
 
-            var languageClass = sourceHandler.getClassBasedOnExtension(args.container) || '';
+            const languageClass = sourceHandler.getClassBasedOnExtension(args.container) || '';
             container.classList.add(languageClass);
 
-            waitForRender(args.diffNode + ' pre').then(() => {
-                var sourceLines = Array.from(document.querySelectorAll(args.diffNode + ' pre:not([class*=language])'));
+            waitForRender(`${args.diffNode}  pre`).then(() => {
+                const sourceLines = Array.from(document.querySelectorAll(`${args.diffNode} pre:not([class*=language])`));
 
                 sourceLines.forEach(line => {
                     const codeElement = sourceHandler.getCodeElementFromPre(line);


### PR DESCRIPTION
I added the side-by-side diff support.  Where applicable I used the functions you've already written to accomplish this.  I also included a few minor changes but I have no problem reverting them if you do not wish to pull them in.

There are a number of .NET specific file extensions that would benefit from syntax highlighting support (my organization is largely a .NET shop) . I also added .sql support since Prism.js supports it out of the box.

While debugging, I noticed a JavaScript error occurs when the merge button is not displayed for merged PRs so I put a check around it

I removed the case sensitivity for extension/language resolution.  Since Windows is somewhat wonky the way it preserves case, it would make things smoother on the Windows side if the language check is not case sensitive.  If you feel differently, I will remove the this change.
##### One Suggestion:

I noticed that the build npm browserfiy build task has a wild card in the command.  Unfortunately, after a bit of Googling, it would seem this is not platform agnostic i.e. (it breaks in Windows). I would suggest mentioning this in the readme if you decide to keep the wildcard and continue to accept community contributions.
