### PR TITLE
fix(#41): Apply syntax highlighting to diffs loaded on user demand when PR is too big.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,3 +7,4 @@ Please try to keep the list in order.
 - [Andre](http://github.com/andremw)
 - [Gregory McQuillan](http://github.com/hk0i)
 - [Rodrigo Proença](http://github.com/rproenca)
+- [Ronald Rey](http://github.com/reyronald)

--- a/src/syntax-highlight/language-ext.js
+++ b/src/syntax-highlight/language-ext.js
@@ -10,6 +10,7 @@ module.exports = {
     '.xml': 'language-markup',
     '.html': 'language-markup',
     '.js': 'language-javascript',
+    '.styl': 'language-stylus',
     '.css': 'language-css',
     '.cs': 'language-csharp',
     '.cshtml': 'language-markup',
@@ -51,10 +52,12 @@ module.exports = {
     '.scala': 'language-scala',
     '.sfproj': 'language-markup',
     '.sql': 'language-sql',
+    '.svcmap': 'language-markup',
     '.swift': 'language-swift',
     '.ts': 'language-typescript',
     '.wxs': 'language-markup',
     '.xaml': 'language-markup',
+    '.xsd': 'language-markup',
     '.yaml': 'language-yaml',
     '.yml': 'language-yaml'
 };

--- a/src/syntax-highlight/source-handler.js
+++ b/src/syntax-highlight/source-handler.js
@@ -33,6 +33,18 @@ module.exports.getClassBasedOnExtension = function getClassBasedOnExtension(elem
     return languagesExtensions[fileExtension.toLowerCase()] || '';
 };
 
+/**
+ * Retrieves the filename of an element according to its `data-identifier`, * `data-filename` or `data-path` attributes.
+ *
+ * @param  {Element} element An HTML element. Pass anything different and bear the consequences :)
+ * @return {String} The filename
+ */
 function getFilepathFromElement(element) {
-    return element.getAttribute('data-filename') || element.getAttribute('data-path') || '';
+    const filepath = element.getAttribute('data-identifier') ||
+        element.getAttribute('data-filename') ||
+        element.getAttribute('data-path') ||
+        '';
+    return filepath.trim();
 }
+
+module.exports.getFilepathFromElement = getFilepathFromElement;

--- a/src/wait-for-render.js
+++ b/src/wait-for-render.js
@@ -1,5 +1,5 @@
 const INTERVAL = 50; // Interval in milliseconds.
-const TIMEOUT = 2500;
+const TIMEOUT = 5000;
 
 /**
  * Waits some intervals until a specific element is displayed.
@@ -10,7 +10,7 @@ module.exports = function waitForRender(selector) {
         const element = document.querySelector(selector);
 
         if (element) {
-            resolve();
+            resolve(element);
         }
 
         let totalWaitTime = 0;
@@ -27,7 +27,7 @@ module.exports = function waitForRender(selector) {
 
             // If element is rendered, stop the interval and continue.
             clearInterval(intervalId);
-            resolve();
+            resolve(element);
         }, INTERVAL);
     });
 };


### PR DESCRIPTION
A few things to highlight about the PR:

- The classic for loop inside the new `MutationObserver` is intentional. Although unquestionably uglier, is it orders of magnitude more performant than using the functional approach, specially inside the observer callback, which may fire multiple times per second.
- I modified the `'highlight'` event flow so that it receives the container it is supposed to operate on. Before, everytime the '`highlight'` event was fired (which was every time the user requested to load more lines of code of any diff), the extension would run through the whole document, going through nodes of already processed containers. For very large PRs, this is definitely noticeable.
- I modified the `transformPreElements()` function so that it only wraps the contents of the `<pre>` tags in `<code>` tags when it has no child nodes (in other words, when it only has text). Before, I noticed that sometimes the source lines would end up with a `<pre><code><code><code>...`  structure.
- Bitbucket has a predefined timeout for the PR page to load that's above 2.5 seconds. When it takes more time beyond that timeout, it renders all the diffs it has available at the moment and the remaining ones are loaded when user demands with the "Click here to try again" link. I increased the timeout constant of the `waitForRender` method to be above Bitbucket's limit, that way, as of the current Bitbucket's implementation, no PR will ever load with unhighlighted text, which was the case when it took more than 2.5 seconds before.

I tried to include as little code as possible to fix this issue, while messing the least I could with the structure and any previously existing code. That said, I did notice a few bottlenecks and performance improvements that could be made. I deal with very large PRs in my work environment on a regular basis (hundreds of files, tens of thousands of diff lines) and in those cases the poor performance becomes a little noticeable. If any other user brings it up or there's interest, I'm willing to be part of the effort to improve it.

Before
![before](https://user-images.githubusercontent.com/7514993/28243637-23abc140-69a0-11e7-825c-b548a694924f.gif)

After
![after](https://user-images.githubusercontent.com/7514993/28243638-2bb06f1c-69a0-11e7-8b93-33ab513cf3e5.gif)

