### PR TITLE
fix(highlighter): keep selected text after double click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # _Next version_
 
+### Bug Fixes
+
+* **Highlighter**: Now the selection is maintained when highlighting word occurrences, [PR 50](https://github.com/refined-bitbucket/refined-bitbucket/pull/50).
+
 ### Language support:
 
 * Added C++ language support for files with extension `.cc`

--- a/src/occurrences-highlighter/occurrences-highlighter.js
+++ b/src/occurrences-highlighter/occurrences-highlighter.js
@@ -4,6 +4,8 @@
 
 const waitForRender = require('../wait-for-render.js');
 
+const SELECTION_TEMPORARY_ID = '__refined_bitbucket_selection_temporary_id';
+
 module.exports = (function () {
     return {
         init
@@ -29,24 +31,70 @@ function highlightOnDoubleClick() {
     $('.diff-content-container').dblclick(function () {
         const $this = $(this);
         const code = $($this.closest('.diff-content-container')[0]).find('pre');
-        const text = getSelectedText().toString();
+        const selection = getSelectedText();
+        const text = selection.toString().trim();
+        const span = wrapInSpan(selection.anchorNode, SELECTION_TEMPORARY_ID);
 
         code.unhighlight();
         code.highlight(text, {
             caseSensitive: true,
             wordsOnly: true
         });
+
+        const children = unwrapChildren(span);
+        const highlighted = [...children].find(node => node.classList.contains('highlight'));
+        if (highlighted) {
+            selectElementContents(highlighted);
+        }
     });
 }
 
 function getSelectedText() {
-    let selection = '';
     if (window.getSelection) {
-        selection = window.getSelection();
-    } else if (document.getSelection) {
-        selection = document.getSelection();
-    } else if (document.selection) {
-        selection = document.selection.createRange().text;
+        return window.getSelection();
     }
-    return selection;
+    if (document.getSelection) {
+        return document.getSelection();
+    }
+    if (document.selection) {
+        return document.selection.createRange().text;
+    }
+    return '';
+}
+
+/**
+ * Wraps the given DOM Element in a span with the given ID
+ * @param {HTMLElement} el
+ * @param {string} id
+ * @returns {HTMLElement}
+ */
+function wrapInSpan(el, id) {
+    const wrapper = document.createElement('span');
+    wrapper.id = id;
+    $(el).wrap(wrapper);
+    return el.parentNode;
+}
+
+/**
+ * Unwraps all the children of the given element
+ * @param {HTMLElement} el
+ * @returns {HTMLElement[]} - An array of the elements children
+ */
+function unwrapChildren(el) {
+    if (el && el.firstElementChild) {
+        return $(el.firstElementChild).unwrap();
+    }
+    return [];
+}
+
+/**
+ * Selects the HTMLElement element's contents
+ * @param {HTMLElement} element
+ */
+function selectElementContents(element) {
+    const range = document.createRange();
+    range.selectNodeContents(element);
+    const selection = window.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(range);
 }


### PR DESCRIPTION
In the previous behavior, after double clicking a word in a PR the text was deselected.
Now the selection is maintained after the highlighting occurs.

Closes issue #38 

**Before:**

![before](https://user-images.githubusercontent.com/7514993/30448033-a2d09db6-995b-11e7-8d27-1193a12f5f6a.gif)

**After:**

![after](https://user-images.githubusercontent.com/7514993/30448047-a815dd4a-995b-11e7-98e5-48664c2bd587.gif)

**EDIT:** Just a clarification, in the _after_ gif the text is deselected because I actually clicked outside of the selection, not because the extension did it 😅 
