### PR TITLE
fix(ocurrences-highlighter): keep selection after double click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
+# Next Version
+
+### Bug fixes
+
+* **Ocurrences-Highlighter**: Words are not deselected when selected through double-clicking inside comments and tasks, closes [issue #52](https://github.com/refined-bitbucket/refined-bitbucket/issues/52), [pull request 53](https://github.com/refined-bitbucket/refined-bitbucket/pull/53).
+
 # 2.6.1 (2017-06-27)
 
 ### Bug Fixes
 
-* **Highlighter**: Now the selection is maintained when highlighting word occurrences, [PR 50](https://github.com/refined-bitbucket/refined-bitbucket/pull/50).
+* **Ocurrences-Highlighter**: Now the selection is maintained when highlighting word occurrences, closes [issue #38](https://github.com/refined-bitbucket/refined-bitbucket/issues/38), [pull request 50](https://github.com/refined-bitbucket/refined-bitbucket/pull/50).
 
-### Language support:
+### Language support
 
 * Added C++ language support for files with extension `.cc`
 * Added JSX language support for VueJS files with extension `.vue`

--- a/src/occurrences-highlighter/occurrences-highlighter.js
+++ b/src/occurrences-highlighter/occurrences-highlighter.js
@@ -30,7 +30,11 @@ function insertStyles() {
 function highlightOnDoubleClick() {
     $('.diff-content-container').dblclick(function () {
         const $this = $(this);
-        const code = $($this.closest('.diff-content-container')[0]).find('pre');
+
+        // <pre> for lines of code
+        // <p> for comments
+        // <span> for tasks
+        const code = $($this.closest('.diff-content-container')[0]).find('pre, p, span');
         const selection = getSelectedText();
         const text = selection.toString().trim();
         const span = wrapInSpan(selection.anchorNode, SELECTION_TEMPORARY_ID);


### PR DESCRIPTION
Now words are not deselected when selected through double-clicking inside comments and tasks.

Also, any occurrence of the word is highlighted not only in code-blocks, but also in comment boxes and tasks as well.

Closes issue #52

### Before:

![before](https://user-images.githubusercontent.com/7514993/31186396-7f50c81a-a8fc-11e7-87c3-a939df28348a.gif)

### After:

![after](https://user-images.githubusercontent.com/7514993/31186403-86b293d6-a8fc-11e7-99df-ba0b9120859e.gif)
