### PR TITLE
fix(occur-high): keep selection after dblclk in textarea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
+# Next Version
+
+### Bug fixes
+
+* **Ocurrences-Highlighter**: Now the selection is maintained when highlighting word occurrences when creating comments and tasks, closes [issue #52](https://github.com/refined-bitbucket/refined-bitbucket/issues/52), [pull request 53](https://github.com/refined-bitbucket/refined-bitbucket/pull/53).
+
+
 # 2.6.2 (2017-10-12)
 
 ### Bug fixes
 
-* **Ocurrences-Highlighter**: Words are not deselected when selected through double-clicking inside comments and tasks, closes [issue #52](https://github.com/refined-bitbucket/refined-bitbucket/issues/52), [pull request 53](https://github.com/refined-bitbucket/refined-bitbucket/pull/53).
+* **Ocurrences-Highlighter**: Now the selection is maintained when highlighting word occurrences inside comments and tasks, closes [issue #52](https://github.com/refined-bitbucket/refined-bitbucket/issues/52), [pull request 53](https://github.com/refined-bitbucket/refined-bitbucket/pull/53).
 
 # 2.6.1 (2017-09-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bug fixes
 
-* **Ocurrences-Highlighter**: Now the selection is maintained when highlighting word occurrences when creating comments and tasks, closes [issue #52](https://github.com/refined-bitbucket/refined-bitbucket/issues/52), [pull request 53](https://github.com/refined-bitbucket/refined-bitbucket/pull/53).
+* **Ocurrences-Highlighter**: Now the selection is maintained when highlighting word occurrences when creating comments and tasks, closes [issue #55](https://github.com/refined-bitbucket/refined-bitbucket/issues/55), [pull request 56](https://github.com/refined-bitbucket/refined-bitbucket/pull/56).
 
 
 # 2.6.2 (2017-10-12)

--- a/extension/vendor/jquery.highlight.js
+++ b/extension/vendor/jquery.highlight.js
@@ -1,15 +1,155 @@
-jQuery.extend({highlight:function(e,t,i,n){if(3===e.nodeType){var r=e.data.match(t)
-if(r){var a=document.createElement(i||"span")
-a.className=n||"highlight"
-var h=e.splitText(r.index)
-h.splitText(r[0].length)
-var s=h.cloneNode(!0)
-return a.appendChild(s),h.parentNode.replaceChild(a,h),1}}else if(1===e.nodeType&&e.childNodes&&!/(script|style)/i.test(e.tagName)&&(e.tagName!==i.toUpperCase()||e.className!==n))for(var l=0;l<e.childNodes.length;l++)l+=jQuery.highlight(e.childNodes[l],t,i,n)
-return 0}}),jQuery.fn.unhighlight=function(e){var t={className:"highlight",element:"span"}
-return jQuery.extend(t,e),this.find(t.element+"."+t.className).each(function(){var e=this.parentNode
-e.replaceChild(this.firstChild,this),e.normalize()}).end()},jQuery.fn.highlight=function(e,t){var i={className:"highlight",element:"span",caseSensitive:!1,wordsOnly:!1}
-if(jQuery.extend(i,t),e.constructor===String&&(e=[e]),e=jQuery.grep(e,function(e,t){return""!=e}),e=jQuery.map(e,function(e,t){return e.replace(/[-[\]{}()*+?.,\\^$|#\s]/g,"\\$&")}),0==e.length)return this
-var n=i.caseSensitive?"":"i",r="("+e.join("|")+")"
-i.wordsOnly&&(r="\\b"+r+"\\b")
-var a=RegExp(r,n)
-return this.each(function(){jQuery.highlight(this,a,i.element,i.className)})}
+/*
+ * jQuery Highlight plugin
+ *
+ * Based on highlight v3 by Johann Burkard
+ * http://johannburkard.de/blog/programming/javascript/highlight-javascript-text-higlighting-jquery-plugin.html
+ *
+ * Code a little bit refactored and cleaned (in my humble opinion).
+ * Most important changes:
+ *  - has an option to highlight only entire words (wordsOnly - false by default),
+ *  - has an option to be case sensitive (caseSensitive - false by default)
+ *  - highlight element tag and class names can be specified in options
+ *
+ * Usage:
+ *   // wrap every occurrence of text 'lorem' in content
+ *   // with <span class='highlight'> (default options)
+ *   $('#content').highlight('lorem');
+ *
+ *   // search for and highlight more terms at once
+ *   // so you can save some time on traversing DOM
+ *   $('#content').highlight(['lorem', 'ipsum']);
+ *   $('#content').highlight('lorem ipsum');
+ *
+ *   // search only for entire word 'lorem'
+ *   $('#content').highlight('lorem', { wordsOnly: true });
+ *
+ *   // search only for the entire word 'C#'
+ *   // and make sure that the word boundary can also
+ *   // be a 'non-word' character, as well as a regex latin1 only boundary:
+ *   $('#content').highlight('C#', { wordsOnly: true , wordsBoundary: '[\\b\\W]' });
+ *
+ *   // don't ignore case during search of term 'lorem'
+ *   $('#content').highlight('lorem', { caseSensitive: true });
+ *
+ *   // wrap every occurrence of term 'ipsum' in content
+ *   // with <em class='important'>
+ *   $('#content').highlight('ipsum', { element: 'em', className: 'important' });
+ *
+ *   // remove default highlight
+ *   $('#content').unhighlight();
+ *
+ *   // remove custom highlight
+ *   $('#content').unhighlight({ element: 'em', className: 'important' });
+ *
+ *
+ * Copyright (c) 2009 Bartek Szopka
+ *
+ * Licensed under MIT license.
+ *
+ */
+
+(function (factory) {
+    if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define(['jquery'], factory);
+    } else if (typeof exports === 'object') {
+        // Node/CommonJS
+        factory(require('jquery'));
+    } else {
+        // Browser globals
+        factory(jQuery);
+    }
+}(function (jQuery) {
+    jQuery.extend({
+        highlight: function (node, re, nodeName, className, callback) {
+            if (node.nodeType === 3) {
+                var match = node.data.match(re);
+                if (match) {
+                    // The new highlight Element Node
+                    var highlight = document.createElement(nodeName || 'span');
+                    highlight.className = className || 'highlight';
+                    // Note that we use the captured value to find the real index
+                    // of the match. This is because we do not want to include the matching word boundaries
+                    var capturePos = node.data.indexOf( match[1] , match.index );
+
+                    // Split the node and replace the matching wordnode
+                    // with the highlighted node
+                    var wordNode = node.splitText(capturePos);
+                    wordNode.splitText(match[1].length);
+
+                    var wordClone = wordNode.cloneNode(true);
+                    highlight.appendChild(wordClone);
+                    wordNode.parentNode.replaceChild(highlight, wordNode);
+                    if (typeof callback == 'function') {
+                        callback(highlight)   
+                    }
+                    return 1; //skip added node in parent
+                }
+            } else if ((node.nodeType === 1 && node.childNodes) && // only element nodes that have children
+                    !/(script|style)/i.test(node.tagName) && // ignore script and style nodes
+                    !(node.tagName === nodeName.toUpperCase() && node.className === className)) { // skip if already highlighted
+                for (var i = 0; i < node.childNodes.length; i++) {
+                    i += jQuery.highlight(node.childNodes[i], re, nodeName, className, callback);
+                }
+            }
+            return 0;
+        }
+    });
+
+    jQuery.fn.unhighlight = function (options) {
+        var settings = {
+          className: 'highlight',
+          element: 'span'
+        };
+
+        jQuery.extend(settings, options);
+
+        return this.find(settings.element + '.' + settings.className).each(function () {
+            var parent = this.parentNode;
+            parent.replaceChild(this.firstChild, this);
+            parent.normalize();
+        }).end();
+    };
+
+    jQuery.fn.highlight = function (words, options, callback) {
+        var settings = {
+          className: 'highlight',
+          element: 'span',
+          caseSensitive: false,
+          wordsOnly: false,
+          wordsBoundary: '\\b'
+        };
+
+        jQuery.extend(settings, options);
+
+        if (typeof words === 'string') {
+          words = [words];
+        }
+        words = jQuery.grep(words, function(word, i){
+          return word != '';
+        });
+        words = jQuery.map(words, function(word, i) {
+          return word.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+        });
+
+        if (words.length === 0) {
+          return this;
+        };
+
+        var flag = settings.caseSensitive ? '' : 'i';
+        // The capture parenthesis will make sure we can match
+        // only the matching word
+        var pattern = '(' + words.join('|') + ')';
+        if (settings.wordsOnly) {
+            pattern =
+                (settings.wordsBoundaryStart || settings.wordsBoundary) +
+                pattern +
+                (settings.wordsBoundaryEnd || settings.wordsBoundary);
+        }
+        var re = new RegExp(pattern, flag);
+
+        return this.each(function () {
+            jQuery.highlight(this, re, settings.element, settings.className, callback);
+        });
+    };
+}));


### PR DESCRIPTION
Now words are not deselected when selected through double-clicking inside the textarea of a comment or task creation.

Closes issue #55