### PR TITLE
fix(occur-high): selection doesn't jump to a previous instance of the word

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Next Version
+
+### Bug fixes
+
+* **Ocurrences-Highlighter**: When double-clicking a word that exists multiple times in the same HTML node, the selection remains in the clicked word, closes [issue #57](https://github.com/refined-bitbucket/refined-bitbucket/issues/57), [pull request 58](https://github.com/refined-bitbucket/refined-bitbucket/pull/58).
+
 # 2.6.3 (2017-10-15)
 
 ### Bug fixes
@@ -13,7 +19,7 @@
 
 # 2.6.1 (2017-09-27)
 
-### Bug Fixes
+### Bug fixes
 
 * **Ocurrences-Highlighter**: Now the selection is maintained when highlighting word occurrences, closes [issue #38](https://github.com/refined-bitbucket/refined-bitbucket/issues/38), [pull request 50](https://github.com/refined-bitbucket/refined-bitbucket/pull/50).
 

--- a/src/occurrences-highlighter/occurrences-highlighter.js
+++ b/src/occurrences-highlighter/occurrences-highlighter.js
@@ -1,4 +1,4 @@
-/* global $, window */
+/* global $, window, Text */
 
 'use strict';
 
@@ -32,9 +32,9 @@ function highlightOnDoubleClick() {
         const $this = $(this);
 
         // <pre> for lines of code
-        // <p> for comments
+        // <div class="comment-content"> for comments
         // <span class="description"> for tasks
-        const code = $($this.closest('.diff-content-container')[0]).find('pre, p, span.description');
+        const code = $($this.closest('.diff-content-container')[0]).find('pre, div.comment-content, span.description');
         const selection = getSelectedText();
         const selectionIsInTextArea = selection.anchorNode.getElementsByTagName && selection.anchorNode.getElementsByTagName('textarea').length;
         const text = selection.toString();
@@ -44,7 +44,8 @@ function highlightOnDoubleClick() {
         if (selectionIsInTextArea) {
             highlightOcurrences(code, text);
         } else {
-            const span = wrapInSpan(selection.anchorNode, SELECTION_TEMPORARY_ID);
+            const selectedNode = getSelectionAsNode(selection);
+            const span = wrapInSpan(selectedNode, SELECTION_TEMPORARY_ID);
             highlightOcurrences(code, text);
             const children = unwrapChildren(span);
             const highlightedNode = getHighlightedNode(children);
@@ -82,6 +83,20 @@ function highlightOcurrences(code, text) {
         wordsBoundaryStart: '(',
         wordsBoundaryEnd: ')'
     });
+}
+
+/**
+ * Gets the selection as a HTML element node.
+ * @param {Selection} selection
+ * @returns {HTMLElement}
+ */
+function getSelectionAsNode(selection) {
+    if (selection.anchorNode instanceof Text) {
+        const word = selection.anchorNode.splitText(selection.anchorOffset);
+        word.splitText(selection.focusOffset);
+        return word;
+    }
+    return selection.anchorNode;
 }
 
 /**

--- a/src/occurrences-highlighter/occurrences-highlighter.js
+++ b/src/occurrences-highlighter/occurrences-highlighter.js
@@ -1,4 +1,4 @@
-/* global $, window */
+/* global $, window, Text */
 
 'use strict';
 
@@ -87,7 +87,7 @@ function highlightOcurrences(code, text) {
 
 /**
  * Gets the selection as a HTML element node.
- * @param {Selection} selection 
+ * @param {Selection} selection
  * @returns {HTMLElement}
  */
 function getSelectionAsNode(selection) {

--- a/src/occurrences-highlighter/occurrences-highlighter.js
+++ b/src/occurrences-highlighter/occurrences-highlighter.js
@@ -32,9 +32,9 @@ function highlightOnDoubleClick() {
         const $this = $(this);
 
         // <pre> for lines of code
-        // <p> for comments
+        // <div class="comment-content"> for comments
         // <span class="description"> for tasks
-        const code = $($this.closest('.diff-content-container')[0]).find('pre, p, span.description');
+        const code = $($this.closest('.diff-content-container')[0]).find('pre, div.comment-content, span.description');
         const selection = getSelectedText();
         const selectionIsInTextArea = selection.anchorNode.getElementsByTagName && selection.anchorNode.getElementsByTagName('textarea').length;
         const text = selection.toString();
@@ -44,7 +44,8 @@ function highlightOnDoubleClick() {
         if (selectionIsInTextArea) {
             highlightOcurrences(code, text);
         } else {
-            const span = wrapInSpan(selection.anchorNode, SELECTION_TEMPORARY_ID);
+            const selectedNode = getSelectionAsNode(selection);
+            const span = wrapInSpan(selectedNode, SELECTION_TEMPORARY_ID);
             highlightOcurrences(code, text);
             const children = unwrapChildren(span);
             const highlightedNode = getHighlightedNode(children);
@@ -82,6 +83,20 @@ function highlightOcurrences(code, text) {
         wordsBoundaryStart: '(',
         wordsBoundaryEnd: ')'
     });
+}
+
+/**
+ * Gets the selection as a HTML element node.
+ * @param {Selection} selection 
+ * @returns {HTMLElement}
+ */
+function getSelectionAsNode(selection) {
+    if (selection.anchorNode instanceof Text) {
+        const word = selection.anchorNode.splitText(selection.anchorOffset);
+        word.splitText(selection.focusOffset);
+        return word;
+    }
+    return selection.anchorNode;
 }
 
 /**


### PR DESCRIPTION
In the previous behavior, when double-clicking a word that exists multiple times in the same HTML node,
the selection always jumped to the first occurrence of the word in that element.

Closes issue #57