### PR TITLE
fix(collapse-diff): when diff change is only a file rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Features
 
-* **Collapse-Diff**: Added button to collapse diffs in the Pull Request view. [Pull request 60](https://github.com/refined-bitbucket/refined-bitbucket/pull/60).
+* **Collapse-Diff**: Added button to collapse diffs in the Pull Request view. [Pull request 60](https://github.com/refined-bitbucket/refined-bitbucket/pull/60) and [pull request 67](https://github.com/refined-bitbucket/refined-bitbucket/pull/67).
 
 ### Improvements
 

--- a/package.json
+++ b/package.json
@@ -39,11 +39,11 @@
   "homepage": "https://github.com/refined-bitbucket/refined-bitbucket#readme",
   "devDependencies": {
     "adm-zip": "^0.4.7",
-    "browserify": "^13.0.1",
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
     "babel-plugin-transform-react-jsx": "^6.24.1",
+    "browserify": "^13.0.1",
     "cross-env": "^5.1.0",
     "path": "^0.12.7",
     "semver": "^5.4.1",
@@ -64,7 +64,15 @@
     "globals": [
       "document",
       "MutationObserver"
-    ]
+    ],
+    "rules": {
+      "no-unused-vars": [
+        2,
+        {
+          "varsIgnorePattern": "^h$"
+        }
+      ]
+    }
   },
   "babel": {
     "plugins": [

--- a/src/collapse-diff/collapse-diff.js
+++ b/src/collapse-diff/collapse-diff.js
@@ -1,75 +1,55 @@
 'use strict';
 
-const COLLAPSE_DIFF_BUTTON_CLASS = '__refined_bitbucket_collapse_diff_button';
+import {h} from 'dom-chef';
+import 'selector-observer';
+import waitForPullRequestContents from '../wait-for-pullrequest';
 
-module.exports = (function () {
-    return {
-        init() {
-            insertStyles();
+export function init() {
+    insertStyles();
 
-            waitForPullRequestContents().then(pullRequestContentsNode => {
-                // insert the collapse diff button in every diff loaded initially with the page
-                insertCollapseDiffButton(pullRequestContentsNode);
-
-                // observe the DOM for any diff loaded on user demand after that
-                pullRequestContentsNode.observeSelector('div.diff-container', function () {
-                    insertCollapseDiffButton(this);
-                });
-            });
-        }
-    };
-})();
+    waitForPullRequestContents().then(pullRequestContentsNode => {
+        // have to observe the DOM because some diffs
+        // can be loaded by user demand at any moment
+        pullRequestContentsNode.observeSelector('div.diff-container', function () {
+            insertCollapseDiffButton(this);
+        });
+    })
+    .catch(() => {
+        // current page is not a pull request, ignore
+    });
+}
 
 function insertStyles() {
     const head = document.getElementsByTagName('head')[0];
     const style = document.createElement('style');
     style.type = 'text/css';
-    style.innerHTML = '.__refined_bitbucket_hide { display: none; } .__refined_bitbucket_bottom_border { border-bottom: 1px solid #ccc !important; }';
+    style.textContent = `
+        .__refined_bitbucket_hide { display: none; }
+        .__refined_bitbucket_bottom_border { border-bottom: 1px solid #ccc !important; }
+    `;
     head.appendChild(style);
 }
 
-function waitForPullRequestContents() {
-    return new Promise(resolve => {
-        const pullRequestContentsNode = document.getElementById('pr-tab-content');
+function insertCollapseDiffButton(diffContainer) {
+    const button = (
+        <div class="aui-buttons">
+            <button type="button" class="aui-button aui-button-light __refined_bitbucket_collapse_diff_button" aria-label="Toggle diff text" data-initial-state="true">
+                <svg aria-hidden="true" height="16" version="1.1" viewBox="0 0 10 16" width="10">
+                    <path fill-rule="evenodd" d="M10 10l-1.5 1.5L5 7.75 1.5 11.5 0 10l5-5z"></path>
+                </svg>
+                <svg aria-hidden="true" height="16" version="1.1" viewBox="0 0 10 16" width="10" class="__refined_bitbucket_hide">
+                    <path fill-rule="evenodd" d="M5 11L0 6l1.5-1.5L5 8.25 8.5 4.5 10 6z"></path>
+                </svg>
+            </button>
+        </div>
+    );
 
-        new MutationObserver(function (mutations) {
-            const maskRemoved = mutations.every(m => m.oldValue.includes('has-mask') && !m.target.classList.contains('has-mask'));
-            if (maskRemoved) {
-                this.disconnect();
-                resolve(pullRequestContentsNode);
-            }
-        }).observe(pullRequestContentsNode, {attributes: true, attributeOldValue: true, attributeFilter: ['class']});
-    });
-}
+    const diffAction = diffContainer.querySelector('[id^="side-by-side"].diff-actions.secondary');
+    diffAction.querySelector('div:nth-last-child(3)').insertAdjacentElement('afterend', button);
 
-function insertCollapseDiffButton(container) {
-    // exit early if button is already inserted
-    if (container.getElementsByClassName(COLLAPSE_DIFF_BUTTON_CLASS).length) {
-        return;
-    }
-
-    const htmlString = `
-      <div class="aui-buttons">
-        <button type="button" class="${COLLAPSE_DIFF_BUTTON_CLASS} aui-button aui-button-light" aria-label="Toggle diff text" data-initial-state="true">
-            <svg aria-hidden="true" height="16" version="1.1" viewBox="0 0 10 16" width="10">
-                <path fill-rule="evenodd" d="M10 10l-1.5 1.5L5 7.75 1.5 11.5 0 10l5-5z"></path>
-            </svg>
-            <svg aria-hidden="true" height="16" version="1.1" viewBox="0 0 10 16" width="10" class="__refined_bitbucket_hide">
-                <path fill-rule="evenodd" d="M5 11L0 6l1.5-1.5L5 8.25 8.5 4.5 10 6z"></path>
-            </svg>
-        </button>
-      </div>
-    `;
-
-    const diffActions = container.querySelectorAll('[id^="side-by-side"].diff-actions.secondary');
-    diffActions.forEach(diffAction => {
-        diffAction.querySelector('div:nth-last-child(3)').insertAdjacentHTML('afterend', htmlString);
-    });
-
-    [...container.getElementsByClassName(COLLAPSE_DIFF_BUTTON_CLASS)].forEach(button => button.addEventListener('click', function () {
-        const diffContainer = this.closest('div.diff-container');
+    button.addEventListener('click', function () {
         // Hide/show the diff
-        const diffContentContainer = diffContainer.querySelector('div.diff-content-container.refract-container');
+        const diffContentContainer = diffContainer.querySelector('div.diff-content-container');
         diffContentContainer.classList.toggle('__refined_bitbucket_hide');
 
         // Hide/show diff message, if present (when there are conflicts, for example)
@@ -83,5 +63,5 @@ function insertCollapseDiffButton(container) {
 
         // Toggle the collapse button icon
         [...this.getElementsByTagName('svg')].forEach(svg => svg.classList.toggle('__refined_bitbucket_hide'));
-    }));
+    });
 }

--- a/src/wait-for-pullrequest.js
+++ b/src/wait-for-pullrequest.js
@@ -1,0 +1,19 @@
+'use strict';
+
+export default function waitForPullRequestContents() {
+    return new Promise((resolve, reject) => {
+        const pullRequestContentsNode = document.getElementById('pr-tab-content');
+
+        if (!pullRequestContentsNode) {
+            reject('Current page is not a pull request');
+        }
+
+        new MutationObserver(function (mutations) {
+            const maskRemoved = mutations.every(m => m.oldValue.includes('has-mask') && !m.target.classList.contains('has-mask'));
+            if (maskRemoved) {
+                this.disconnect();
+                resolve(pullRequestContentsNode);
+            }
+        }).observe(pullRequestContentsNode, {attributes: true, attributeOldValue: true, attributeFilter: ['class']});
+    });
+}


### PR DESCRIPTION
The `div.diff-content` node classes are different if the diff has content changes or not. Only fix needed was to relax the query selector so that it could select the div in both cases.

Closes issue #66 