### PR TITLE
feat(load-all-diffs): add button to load all failed diffs in PR view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * **Collapse-Diff**: Added button to collapse diffs in the Pull Request view. [Pull request 60](https://github.com/refined-bitbucket/refined-bitbucket/pull/60) and [pull request 67](https://github.com/refined-bitbucket/refined-bitbucket/pull/67).
 * **Autocollapse**: Add file patterns in the Options page that you would like the extension to collapse automatically when the Pull Request. [Pull request 68](https://github.com/refined-bitbucket/refined-bitbucket/pull/68).
 * **Pullrequest-ignore**: Add diff filename patterns in the Options page that you would like the extension to completely remove automatically when the Pull Request loads. [Pull request 70](https://github.com/refined-bitbucket/refined-bitbucket/pull/70).
+* **Load-all-diffs**: Add button to load all failed diffs in Pull Request view. [Pull request 71](https://github.com/refined-bitbucket/refined-bitbucket/pull/71).
 
 ### Improvements
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ and made a few improvements. Kudos!
 - ~~Block pull request merging without a minimum number of approvals (defaults to 2 minimum approvals).~~ Removed. [Implemented natively by Bitbucket with "merge checks"](https://confluence.atlassian.com/bitbucketserver/checks-for-merging-pull-requests-776640039.html)
 - Key binding feature, which allows for quicker navigation through pull requests.
 - Button to collapse diffs in Pull Request view.
+- Autocollapse. Add file patterns in the Options page that you would like the extension to collapse automatically when the Pull Request.
+- Pullrequest Ignore. Add diff filename patterns in the Options page that you would like the extension to completely remove automatically when the Pull Request loads.
+- Button to load all failed diffs in Pull Request view.
 
 ## Installing
 Refined Bitbucket is [available on the Google Chrome Web Store][chrome-install].

--- a/package-lock.json
+++ b/package-lock.json
@@ -7805,6 +7805,12 @@
           "dev": true
         }
       }
+    },
+    "yoctodelay": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/yoctodelay/-/yoctodelay-1.1.0.tgz",
+      "integrity": "sha512-iCPt7W3X6SCm5wEnMRCoq+c8XCzscKTT0oWq5TNsIb+PUVtNkt/5O3VGlXXlLBnjTKL+29QyTzqbcJNLaiaJyQ==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
     "require": [
       "babel-register"
     ],
-    "babel": "inherit"
+    "babel": "inherit",
+    "timeout": "5s"
   },
   "babel": {
     "presets": [

--- a/src/load-all-diffs/index.js
+++ b/src/load-all-diffs/index.js
@@ -1,0 +1,3 @@
+import {init} from './load-all-diffs';
+
+export default {init};

--- a/src/load-all-diffs/load-all-diffs.js
+++ b/src/load-all-diffs/load-all-diffs.js
@@ -6,7 +6,7 @@ import {h} from 'dom-chef';
 export async function init(node) {
     // Wait for all sections to be loaded into the view
     const filesChanged = node.querySelectorAll('#commit-files-summary > li');
-    
+
     const promises = [...filesChanged].map(li => {
         const dataIdentifier = li.getAttribute('data-file-identifier');
         return elementReady(`section[data-identifier="${dataIdentifier}"]`, {target: node});
@@ -34,7 +34,7 @@ export async function init(node) {
     button.addEventListener('click', async () => {
         button.disabled = true;
         button.textContent = 'Please wait';
-
+        
         const finished = [...node.querySelectorAll('a.try-again')].map(tryAgain => {
             tryAgain.click();
             const dataIdentifier = tryAgain.closest('section').getAttribute('data-identifier');
@@ -44,5 +44,6 @@ export async function init(node) {
         await Promise.all(finished);
 
         button.textContent = 'All diffs loaded successfully';
+        button.setAttribute('data-complete', true);
     });
 }

--- a/src/load-all-diffs/load-all-diffs.js
+++ b/src/load-all-diffs/load-all-diffs.js
@@ -34,7 +34,7 @@ export async function init(node) {
     button.addEventListener('click', async () => {
         button.disabled = true;
         button.textContent = 'Please wait';
-        
+
         const finished = [...node.querySelectorAll('a.try-again')].map(tryAgain => {
             tryAgain.click();
             const dataIdentifier = tryAgain.closest('section').getAttribute('data-identifier');

--- a/src/load-all-diffs/load-all-diffs.js
+++ b/src/load-all-diffs/load-all-diffs.js
@@ -1,0 +1,48 @@
+'use strict';
+
+import elementReady from 'element-ready';
+import {h} from 'dom-chef';
+
+export async function init(node) {
+    // Wait for all sections to be loaded into the view
+    const filesChanged = node.querySelectorAll('#commit-files-summary > li');
+    
+    const promises = [...filesChanged].map(li => {
+        const dataIdentifier = li.getAttribute('data-file-identifier');
+        return elementReady(`section[data-identifier="${dataIdentifier}"]`, {target: node});
+    });
+
+    await Promise.all(promises);
+
+    // Create the button and append it to the file summary list
+    const failedDiffs = node.querySelectorAll('a.try-again');
+    const button = (
+        <button id="__refined_bitbucket_load_all_diffs" class="aui-button">
+            Load all failed diffs ({failedDiffs.length})
+        </button>
+    );
+    const summarySection = node.querySelector('#pullrequest-diff > section.main');
+    summarySection.appendChild(button);
+
+    if (!failedDiffs.length) {
+        button.disabled = true;
+        button.textContent = 'All diffs loaded successfully';
+        return;
+    }
+
+    // Bind the click event
+    button.addEventListener('click', async () => {
+        button.disabled = true;
+        button.textContent = 'Please wait';
+
+        const finished = [...node.querySelectorAll('a.try-again')].map(tryAgain => {
+            tryAgain.click();
+            const dataIdentifier = tryAgain.closest('section').getAttribute('data-identifier');
+            return elementReady(`section[data-identifier="${dataIdentifier}"] > div.diff-container`, {target: node});
+        });
+
+        await Promise.all(finished);
+
+        button.textContent = 'All diffs loaded successfully';
+    });
+}

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@ import waitForPullRequestContents from './wait-for-pullrequest';
 import collapseDiff from './collapse-diff/collapse-diff';
 import autocollapse from './autocollapse/autocollapse';
 import pullrequestIgnore from './pullrequest-ignore';
+import loadAllDiffs from './load-all-diffs';
 
 import 'selector-observer';
 
@@ -30,6 +31,7 @@ storageHelper.getConfig().then(config => {
         collapseDiff.init();
         autocollapse.init(config.autocollapsePaths);
         pullrequestIgnore.init(pullrequestNode, config.ignorePaths);
+        loadAllDiffs.init(pullrequestNode);
 
         // have to observe the DOM because some sections
         // load asynchronously by user demand

--- a/test/load-all-diffs.spec.js
+++ b/test/load-all-diffs.spec.js
@@ -1,0 +1,107 @@
+'use strict';
+
+import test from 'ava';
+import jsdom from 'jsdom';
+import { h } from 'dom-chef';
+import delay from 'yoctodelay';
+import elementReady from 'element-ready';
+
+import loadAllDiffs from '../src/load-all-diffs';
+
+import './setup-jsdom';
+
+/**
+ * Returns the `HTMLElement` representing the node that contains a pull request
+ * @param {string[]} filenames
+ * @return {HTMLDivElement}
+ */
+function getPullrequestNode(filename) {
+    const escapedFilename = escape(filename);
+    const node = (
+        <div id="pr-tab-content">
+            <div id="pullrequest-diff">
+                {/* Header and file summary */}
+                <section class="main">
+                    <h1>Files changed <span>(1)</span></h1>
+                    <ul id="commit-files-summary">
+                        <li data-file-identifier={escapedFilename}><a>{filename}</a></li>
+                    </ul>
+                </section>
+
+                {/* Diffs */}
+                <div id="compare">
+                    <section id="changeset-diff">
+                        <div class="bb-patch bb-patch-unified">
+                            {/* Failed diffs not initially loaded */}
+                        </div>
+                    </section>
+                </div>
+            </div>
+        </div>
+    );
+
+    // Add the failed diff after some delay
+    delay(20).then(() => {
+        const failedDiff = (
+            <section class="bb-udiff" data-identifier={escapedFilename}>
+                <strong class="try-again">Oops! You've got a lot of code in this diff and it couldn't load with the page.</strong>
+                <a class="load-diff try-again">Click here to give it another chance.</a>
+            </section>
+        );
+        const diffsContainer = node.querySelector('div.bb-patch');
+        diffsContainer.appendChild(failedDiff);
+        failedDiff.querySelector('a.try-again').addEventListener('click', function() {
+            // After some other delay, replace the failed diff with a successfull diff
+            delay(20).then(() => {
+                const loadedDiff = (
+                    <section class="bb-udiff" data-identifier={escapedFilename}>
+                        <div class="diff-container"></div>
+                    </section>
+                );
+
+                diffsContainer.replaceChild(loadedDiff, failedDiff);
+            });
+        });
+    });
+
+    return node;
+}
+
+test('should load all failed diffs when button pressed', async t => {
+    // Don't remove the spaces from this filename
+    const filename = '/path/dummy file name.js';
+    const node = getPullrequestNode(filename);
+
+    loadAllDiffs.init(node);
+
+    // Wait for the button to be added after all failed diffs are loaded in the page
+    const button = await elementReadyWithTimeout('button[id="__refined_bitbucket_load_all_diffs"]', {target: node});
+
+    // Assert the initial state of the button
+    t.is(button.disabled, false);
+    t.is(button.textContent, 'Load all failed diffs (1)');
+
+    button.click();
+
+    // Assert the state of the button after being clicked, when failed diffs are reloading
+    t.is(button.disabled, true);
+    t.is(button.textContent, 'Please wait');
+
+    // Wait for the failed diffs to be reloaded
+    await elementReadyWithTimeout(`section[data-identifier="${escape(filename)}"] > div.diff-container`, {target: node});
+
+    // Wait for the button to be updated
+    await elementReadyWithTimeout('button[id="__refined_bitbucket_load_all_diffs"][data-complete="true"]', {target: node});
+
+    // Assert the state of the button after the operation is complete
+    t.is(button.disabled, true);
+    t.is(button.textContent, 'All diffs loaded successfully');
+});
+
+function elementReadyWithTimeout(selector, options, timeout = 1000) {
+    const promise = elementReady(selector, options);
+    setTimeout(function() {
+        promise.cancel();
+    }, timeout);
+    return promise;
+}

--- a/test/setup-jsdom.js
+++ b/test/setup-jsdom.js
@@ -7,5 +7,25 @@ global.window = dom.window;
 global.document = dom.window.document;
 global.Element = dom.window._core.Element;
 global.Text = dom.window._core.Text;
+global.requestAnimationFrame = fn => setTimeout(fn, 16);
+global.cancelAnimationFrame = id => clearTimeout(id);
 
 global.$ = global.jQuery = require('jquery');
+
+// Remove this `closest` shim when this issue is resolved:
+// https://github.com/tmpvar/jsdom/issues/1555
+// https://github.com/tmpvar/jsdom/pull/1951
+const NODE_TYPE = Object.freeze({
+    ELEMENT_NODE: 1,
+});
+window.Element.prototype.closest = window.Element.prototype.closest || function (selectors) {
+    // https://dom.spec.whatwg.org/#dom-element-closest
+    let el = this;
+    while (el && el.nodeType === NODE_TYPE.ELEMENT_NODE) {
+      if (el.matches(selectors)) {
+        return el;
+      }
+      el = el.parentNode;
+    }
+    return null;
+};


### PR DESCRIPTION
**New feature**

Adds a button at the end of the file changes summary to load all failed diffs on the pull request if there are any.

![load-all-diffs](https://user-images.githubusercontent.com/7514993/32376684-da306e0c-c07b-11e7-81e6-bb9c42d21d2e.gif)
