### PR TITLE
fix(collapse-diff): don't duplicate collapse diff button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Next Version
+
+### Bug fixes
+
+* **Collapse-diff**: When using the Bitbucket Diff Tree extension, the "Toggle diff text" button (collapse diff) is not duplicated anymore each time the "Compact/Uncompact empty folder" button is clicked, closes [issue #84](https://github.com/refined-bitbucket/refined-bitbucket/issues/84), [pull request #85](https://github.com/refined-bitbucket/refined-bitbucket/pull/85).
+
 # 3.1.0 (2017-11-20)
 
 ### Features

--- a/src/collapse-diff/collapse-diff.js
+++ b/src/collapse-diff/collapse-diff.js
@@ -23,9 +23,16 @@ function insertStyles() {
 }
 
 function insertCollapseDiffButton(section) {
+    // don't reinsert the button if already present.
+    // doesn't happen with vanilla Bitbucket, but can happen when interacting
+    // with other extensions (like Bitbucket Diff Tree)
+    if (section.getElementsByClassName('__refined_bitbucket_collapse_diff_button').length) {
+        return;
+    }
+
     const button = (
         <div class="aui-buttons">
-            <button type="button" class="aui-button aui-button-light __refined_bitbucket_collapse_diff_button" aria-label="Toggle diff text">
+            <button type="button" class="aui-button aui-button-light __refined_bitbucket_collapse_diff_button" aria-label="Toggle diff text" title="Toggle diff text">
                 <svg aria-hidden="true" height="16" version="1.1" viewBox="0 0 10 16" width="10">
                     <path fill-rule="evenodd" d="M10 10l-1.5 1.5L5 7.75 1.5 11.5 0 10l5-5z"></path>
                 </svg>


### PR DESCRIPTION
When using the _Bitbucket Diff Tree_ extension, the "Toggle diff text" button (collapse diff) is not duplicated anymore each time the "Compact/Uncompact empty folder" button is clicked.

Closes issue #84 

-----------
**Before**:
![before](https://user-images.githubusercontent.com/7514993/33520843-f742b958-d798-11e7-8935-d05a68c8f333.gif)

**After**:
![after](https://user-images.githubusercontent.com/7514993/33520846-fd505d14-d798-11e7-9e81-860c9aa8716b.gif)
