### PR TITLE
feat(collapse-diff): add toggle-diff button at the bottom of the diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Features:
 
-* **Collapse-diff**: A button to toggle the diff text was added at the bottom of the diff. Additionally, clicking this or the previous button at the top will now scroll the diff into view at the top of the page,closes [issue #88](https://github.com/refined-bitbucket/refined-bitbucket/issues/88), [pull request #95](https://github.com/refined-bitbucket/refined-bitbucket/pull/95).
+* **Collapse-diff**: A button to toggle the diff text was added at the bottom of the diff. Additionally, clicking this or the previous button at the top will now scroll the diff into view at the top of the page, closes [issue #88](https://github.com/refined-bitbucket/refined-bitbucket/issues/88), [pull request #95](https://github.com/refined-bitbucket/refined-bitbucket/pull/95).
 
 ### Improvements:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next Version
 
+### Features:
+
+* **Collapse-diff**: A button to toggle the diff text was added at the bottom of the diff. Additionally, clicking this or the previous button at the top will now scroll the diff into view at the top of the page,closes [issue #88](https://github.com/refined-bitbucket/refined-bitbucket/issues/88), [pull request #95](https://github.com/refined-bitbucket/refined-bitbucket/pull/95).
+
 ### Improvements:
 
 * **Collapse-diff**: Test suite for the feature, [pull request #94](https://github.com/refined-bitbucket/refined-bitbucket/pull/94).

--- a/README.md
+++ b/README.md
@@ -67,10 +67,11 @@ We all know BitBucket lacks some features that we have in other platforms like G
 	</tr>
 	<tr>
 		<td>
-			<img src="https://user-images.githubusercontent.com/7514993/31857910-3938deb6-b6b8-11e7-8bac-f55242010a62.gif" alt="options">
+			<img src="https://user-images.githubusercontent.com/7514993/31857910-3938deb6-b6b8-11e7-8bac-f55242010a62.gif" alt="collapse-diff">
+			<img src="https://user-images.githubusercontent.com/7514993/34419580-06327498-ebdb-11e7-90cc-41144d4bd671.gif" alt="bottom-collapse">
 		</td>
 		<td>
-			<img src="https://user-images.githubusercontent.com/7514993/30448047-a815dd4a-995b-11e7-98e5-48664c2bd587.gif" alt="pullrequest-ignore">
+			<img src="https://user-images.githubusercontent.com/7514993/30448047-a815dd4a-995b-11e7-98e5-48664c2bd587.gif" alt="occurrences-highlighter">
 		</td>
 	</tr>
 </table>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2934,9 +2934,9 @@
       }
     },
     "element-ready": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/element-ready/-/element-ready-2.2.0.tgz",
-      "integrity": "sha1-pQRSS7cP1qMQuApr5Jlx5MB1L24=",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/element-ready/-/element-ready-2.2.1.tgz",
+      "integrity": "sha512-W+sbl0W2oVerk/w1mfoIY3r0ayKtYXN+id4uProRGYNm8VroJdnVtCfXv5RHATncLwv4v4te5WGuNi5xUZLjdw==",
       "requires": {
         "p-cancelable": "0.3.0"
       }
@@ -5684,7 +5684,7 @@
     "p-cancelable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-      "integrity": "sha1-ueEjgAvOu3rBOkeb4ZW1B7mNMPo="
+      "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
     },
     "p-finally": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "dom-chef": "^3.0.0",
-    "element-ready": "^2.2.0",
+    "element-ready": "^2.2.1",
     "ignore": "^3.3.6",
     "jquery": "^3.2.1",
     "jquery-highlight": "^3.4.0",

--- a/src/autocollapse/autocollapse.js
+++ b/src/autocollapse/autocollapse.js
@@ -30,9 +30,6 @@ async function collapseIfNeededAsync(section) {
         return;
     }
 
-    // Use the commented line below instead of the one below it when this issue #10 is resolved
-    // https://github.com/sindresorhus/element-ready/issues/10
-    // await elementReady('.__refined_bitbucket_collapse_diff_button', {target: section});
-    await elementReady(`section[data-identifier="${section.getAttribute('data-identifier')}"] .__refined_bitbucket_collapse_diff_button`);
+    await elementReady('.__refined_bitbucket_collapse_diff_button', {target: section});
     toggleDiff(section);
 }

--- a/src/autocollapse/autocollapse.js
+++ b/src/autocollapse/autocollapse.js
@@ -2,6 +2,7 @@
 
 import elementReady from 'element-ready';
 import ignore from 'ignore';
+import {toggleDiff} from '../collapse-diff/collapse-diff';
 
 export default {
     init,
@@ -31,7 +32,7 @@ async function collapseIfNeededAsync(section) {
 
     // Use the commented line below instead of the one below it when this issue #10 is resolved
     // https://github.com/sindresorhus/element-ready/issues/10
-    // const button = await elementReady('.__refined_bitbucket_collapse_diff_button', {target: section});
-    const button = await elementReady(`section[data-identifier="${section.getAttribute('data-identifier')}"] .__refined_bitbucket_collapse_diff_button`);
-    button.click();
+    // await elementReady('.__refined_bitbucket_collapse_diff_button', {target: section});
+    await elementReady(`section[data-identifier="${section.getAttribute('data-identifier')}"] .__refined_bitbucket_collapse_diff_button`);
+    toggleDiff(section);
 }

--- a/src/collapse-diff/collapse-diff.js
+++ b/src/collapse-diff/collapse-diff.js
@@ -7,29 +7,103 @@ export default {
     insertCollapseDiffButton
 };
 
-function init() {
-    insertStyles();
+export function toggleDiff(section) {
+    // Hide/show the diff
+    const diffContentContainer = section.querySelector('div.diff-content-container');
+    if (diffContentContainer) {
+        diffContentContainer.classList.toggle('__refined_bitbucket_hide');
+    }
+
+    // Hide/show diff message, if present (when there are conflicts, for example)
+    const diffMessageContainer = section.querySelector('div.diff-message-container');
+    if (diffMessageContainer) {
+        diffMessageContainer.classList.toggle('__refined_bitbucket_hide');
+    }
+
+    // Add/remove a bottom border to the diff heading
+    section.querySelector('div.heading').classList.toggle('__refined_bitbucket_bottom_border');
+
+    // Toggle the collapse button icon
+    [...section.querySelectorAll('.__refined_bitbucket_collapse_diff_button svg')].forEach(svg => svg.classList.toggle('__refined_bitbucket_hide'));
 }
 
-function insertStyles() {
+
+const insertStyles = () => {
     const head = document.getElementsByTagName('head')[0];
     const style = document.createElement('style');
     style.type = 'text/css';
     style.textContent = `
         .__refined_bitbucket_hide { display: none; }
         .__refined_bitbucket_bottom_border { border-bottom: 1px solid #ccc !important; }
+
+        .skipped-container .__rb_ellipsis {
+            box-sizing: border-box;
+            background: #f5f5f5;
+            border: 1px solid #ccc;
+            border-radius: 3px;
+            box-shadow: 0 0 0 2px #fff;
+            color: #707070;
+            cursor: pointer;
+            display: block;
+            float: left;
+            font-family: Arial,sans-serif;
+            font-size: 20px;
+            height: 16px;
+            line-height: 6px;
+            margin: 0 0 0 21px;
+            padding: 0;
+            position: absolute;
+            text-align: center;
+            width: 30px;
+            z-index: 1
+        }
+
+        .skipped-container .__rb_ellipsis:hover {
+            background-color: #e9e9e9;
+            border-color: #999
+        }
+
+        .skipped-container .__rb_ellipsis::after,.skipped-container .__rb_ellipsis::before {
+            box-sizing: border-box;
+            border: 1px solid #ccc;
+            border-radius: 6px;
+            content: '';
+            height: 9px;
+            left: -4px;
+            position: absolute;
+            width: 36px
+        }
+
+        .skipped-container .__rb_ellipsis::before {
+            border-bottom: none;
+            border-bottom-left-radius: 0;
+            border-bottom-right-radius: 0;
+            content: \'\\2026\';
+            padding: 2px 0 0;
+            top: -4px
+        }
+
+        .skipped-bottom .__rb_ellipsis {
+            margin-top: 12px
+        }
+
+        .skipped-container:last-child .__rb_ellipsis::after {
+            display: none
+        }
+
+        .aui-buttons.__rb_ellipsis::before {
+            width: 38px;
+            content:'';
+        }
     `;
     head.appendChild(style);
+};
+
+function init() {
+    insertStyles();
 }
 
-function insertCollapseDiffButton(section) {
-    // don't reinsert the button if already present.
-    // doesn't happen with vanilla Bitbucket, but can happen when interacting
-    // with other extensions (like Bitbucket Diff Tree)
-    if (section.getElementsByClassName('__refined_bitbucket_collapse_diff_button').length) {
-        return;
-    }
-
+const insertTopButton = section => {
     const button = (
         <div class="aui-buttons">
             <button type="button" class="aui-button aui-button-light __refined_bitbucket_collapse_diff_button" aria-label="Toggle diff text" title="Toggle diff text">
@@ -52,23 +126,70 @@ function insertCollapseDiffButton(section) {
         diffActions.appendChild(button);
     }
 
-    button.addEventListener('click', function () {
-        // Hide/show the diff
-        const diffContentContainer = section.querySelector('div.diff-content-container');
-        if (diffContentContainer) {
-            diffContentContainer.classList.toggle('__refined_bitbucket_hide');
+    return button;
+};
+
+const insertBottomButton = section => {
+    const style = {
+        right: 30,
+        position: 'absolute',
+        height: 'auto',
+        width: 32
+    };
+    const bottomButton = (
+        <div class="aui-buttons __rb_ellipsis" style={style}>
+            <button type="button" class="aui-button aui-button __refined_bitbucket_collapse_diff_button" aria-label="Toggle diff text" title="Toggle diff text" style={{height: 25}}>
+                <svg aria-hidden="true" height="16" version="1.1" viewBox="0 0 10 16" width="10">
+                    <path fill-rule="evenodd" d="M10 10l-1.5 1.5L5 7.75 1.5 11.5 0 10l5-5z"></path>
+                </svg>
+                <svg aria-hidden="true" height="16" version="1.1" viewBox="0 0 10 16" width="10" class="__refined_bitbucket_hide">
+                    <path fill-rule="evenodd" d="M5 11L0 6l1.5-1.5L5 8.25 8.5 4.5 10 6z"></path>
+                </svg>
+            </button>
+        </div>
+    );
+
+    const bottomLine = section.querySelector('div.skipped-bottom.last:last-child');
+    if (bottomLine) {
+        bottomLine.appendChild(bottomButton);
+    } else {
+        const contentContainer = section.querySelector('div.refract-content-container');
+        if (contentContainer) {
+            bottomButton.style.marginTop = 0;
+            const height = {height: 5};
+            const bottomLineContainer = (
+                <div class="skipped-container">
+                    <div class="line-numbers-skipped skipped-bottom last" style={height}></div>
+                    <div class="skipped-bottom last" style={height}>
+                        {bottomButton}
+                    </div>
+                </div>
+            );
+            contentContainer.appendChild(bottomLineContainer);
         }
+    }
 
-        // Hide/show diff message, if present (when there are conflicts, for example)
-        const diffMessageContainer = section.querySelector('div.diff-message-container');
-        if (diffMessageContainer) {
-            diffMessageContainer.classList.toggle('__refined_bitbucket_hide');
-        }
+    return bottomButton;
+};
 
-        // Add/remove a bottom border to the diff heading
-        this.closest('div.heading').classList.toggle('__refined_bitbucket_bottom_border');
+function insertCollapseDiffButton(section) {
+    // don't reinsert the button if already present.
+    // doesn't happen with vanilla Bitbucket, but can happen when interacting
+    // with other extensions (like Bitbucket Diff Tree)
+    if (section.getElementsByClassName('__refined_bitbucket_collapse_diff_button').length) {
+        return;
+    }
 
-        // Toggle the collapse button icon
-        [...this.getElementsByTagName('svg')].forEach(svg => svg.classList.toggle('__refined_bitbucket_hide'));
-    });
+    const onClick = () => {
+        toggleDiff(section);
+
+        // Scrolling to diff
+        section.scrollIntoView({behavior: 'smooth', block: 'start'});
+    };
+
+    const topButton = insertTopButton(section);
+    const bottomButton = insertBottomButton(section);
+
+    topButton.addEventListener('click', onClick);
+    bottomButton.addEventListener('click', onClick);
 }

--- a/test/collapse-diff.spec.js
+++ b/test/collapse-diff.spec.js
@@ -54,6 +54,14 @@ const createNode = () => (
         <div class="diff-content-container refract-container">
             <div class="refract-content-container">
                 <pre>var msg = 'Hello world';</pre>
+
+                <div class="skipped-container">
+                    <div class="line-numbers-skipped skipped-bottom last"></div>
+                    <div class="skipped-bottom last">
+                        {/* Location of the bottom button */}
+                    </div>
+                </div>
+
             </div>
         </div>
     </section>
@@ -65,17 +73,70 @@ test('should not re-insert collapse diff button if already present', async t => 
     collapseDiff.insertCollapseDiffButton(uudiff);
     collapseDiff.insertCollapseDiffButton(uudiff);
     collapseDiff.insertCollapseDiffButton(uudiff);
+    collapseDiff.insertCollapseDiffButton(uudiff);
 
     const buttons = uudiff.getElementsByClassName('__refined_bitbucket_collapse_diff_button');
-    t.true(buttons.length === 1);
+    // one at the top, one at the bottom of the diff
+    t.true(buttons.length === 2);
 });
 
-test('should insert button in correct position when diff loads successfully', async t => {
+test('should insert TOP button in correct position when diff loads successfully', async t => {
     const uudiff = createNode();
 
     collapseDiff.insertCollapseDiffButton(uudiff);
 
     const button = uudiff.querySelector('div.secondary.diff-actions div:nth-child(4)');
+
+    t.truthy(button.querySelector('.__refined_bitbucket_collapse_diff_button'));
+});
+
+test('should insert BOTTOM button in correct position when diff loads successfully', async t => {
+    const uudiff = createNode();
+
+    collapseDiff.insertCollapseDiffButton(uudiff);
+
+    const button = uudiff.querySelector('.refract-content-container .skipped-container .skipped-bottom.last:last-child');
+
+    t.truthy(button.querySelector('.__refined_bitbucket_collapse_diff_button'));
+});
+
+test('should insert BOTTOM button in correct position when diff has no more lines to show', async t => {
+    const uudiff = (
+        <section class="bb-udiff" data-filename="filename.js">
+            <div class="heading">
+                <div class="diff-actions secondary" id="side-by-side-1">
+                    {/* "Side by side" and "View File" buttons */}
+                    <div class="aui-buttons">
+                    </div>
+
+                    {/* "Comment" button */}
+                    <div class="aui-buttons">
+                    </div>
+
+                    {/* "More" button */}
+                    <div class="aui-buttons">
+                    </div>
+
+                    {/* "Collapse-diff" button should go here */}
+
+                </div>
+            </div>
+
+            <div class="diff-content-container refract-container">
+                <div class="refract-content-container">
+                    <pre>var msg = 'Hello world';</pre>
+
+                    {/* If there are no more lines to show at the bottom of the diff,
+                    there is no `<div class="skipped-container">` */}
+
+                </div>
+            </div>
+        </section>
+    );
+
+    collapseDiff.insertCollapseDiffButton(uudiff);
+
+    const button = uudiff.querySelector('.refract-content-container .skipped-container .skipped-bottom.last:last-child');
 
     t.truthy(button.querySelector('.__refined_bitbucket_collapse_diff_button'));
 });

--- a/test/setup-jsdom.js
+++ b/test/setup-jsdom.js
@@ -29,3 +29,7 @@ window.Element.prototype.closest = window.Element.prototype.closest || function 
     }
     return null;
 };
+
+// `scrollIntoView` not supported by jsdom,
+// shim with a no-op
+window.Element.prototype.scrollIntoView = () => {};


### PR DESCRIPTION
Additionally, clicking any of the collapse-diff buttons will now
scroll the diff into view at the top of the page.

Closes issue #88

**Picture**:
![image](https://user-images.githubusercontent.com/7514993/34419604-24ed027c-ebdb-11e7-904b-362d58484475.png)

**Gif** (notice the smooth scrolling in both button clicks):

![bottom-collapse](https://user-images.githubusercontent.com/7514993/34419580-06327498-ebdb-11e7-90cc-41144d4bd671.gif)
