### PR TITLE
fix(syntax-hl): inline code comments gray background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Improvements:
 
 * **Collapse-diff**: Test suite for the feature, [pull request #94](https://github.com/refined-bitbucket/refined-bitbucket/pull/94).
+* **Syntax-highlighting**: Fix for an issue where the styling necessary for syntax highlighting pull requests was interfering with some of Bitbucket's own styling, which caused inline code in comments to have a white background instead of their original gray background, closes [issue #74](https://github.com/refined-bitbucket/refined-bitbucket/issues/74) and [issue #93](https://github.com/refined-bitbucket/refined-bitbucket/issues/93), [pull request #99](https://github.com/refined-bitbucket/refined-bitbucket/pull/99).
 
 # 3.2.0 (2017-12-13)
 

--- a/src/syntax-highlight/syntax-highlight.js
+++ b/src/syntax-highlight/syntax-highlight.js
@@ -20,7 +20,7 @@ export function init() {
     const styleArray = [];
     style.type = 'text/css';
     // Prism css
-    styleArray.push('.token.comment,.token.prolog,.token.doctype,.token.cdata{color: slategray}.token.punctuation{color: #999}.namespace{opacity: .7}.token.property,.token.tag,.token.boolean,.token.number,.token.constant,.token.symbol,.token.deleted{color: #905}.token.selector,.token.attr-name,.token.string,.token.char,.token.builtin,.token.inserted{color: #690}.token.operator,.token.entity,.token.url,.language-css .token.string,.style .token.string{color: #a67f59;background: hsla(0, 0%, 100%, .5)}.token.atrule,.token.attr-value,.token.keyword{color: #07a}.token.function{color: #DD4A68}.token.regex,.token.important,.token.variable{color: #e90}.token.important,.token.bold{font-weight: bold}.token.italic{font-style: italic}.token.entity{cursor: help}');
+    styleArray.push('.token.comment,.token.prolog,.token.doctype,.token.cdata{color: slategray}.token.punctuation{color: #999}.namespace{opacity: .7}.token.property,.token.tag,.token.boolean,.token.number,.token.constant,.token.symbol,.token.deleted{color: #905}.token.selector,.token.attr-name,.token.string,.token.char,.token.builtin,.token.inserted{color: #690}.token.operator,.token.entity,.token.url,.language-css .token.string,.style .token.string{color: #a67f59}.token.atrule,.token.attr-value,.token.keyword{color: #07a}.token.function{color: #DD4A68}.token.regex,.token.important,.token.variable{color: #e90}.token.important,.token.bold{font-weight: bold}.token.italic{font-style: italic}.token.entity{cursor: help}');
     // Custom css to fix some layout problems because of the insertion of <code> element
     styleArray.push(`
         pre > code {

--- a/src/syntax-highlight/syntax-highlight.js
+++ b/src/syntax-highlight/syntax-highlight.js
@@ -22,7 +22,22 @@ export function init() {
     // Prism css
     styleArray.push('.token.comment,.token.prolog,.token.doctype,.token.cdata{color: slategray}.token.punctuation{color: #999}.namespace{opacity: .7}.token.property,.token.tag,.token.boolean,.token.number,.token.constant,.token.symbol,.token.deleted{color: #905}.token.selector,.token.attr-name,.token.string,.token.char,.token.builtin,.token.inserted{color: #690}.token.operator,.token.entity,.token.url,.language-css .token.string,.style .token.string{color: #a67f59;background: hsla(0, 0%, 100%, .5)}.token.atrule,.token.attr-value,.token.keyword{color: #07a}.token.function{color: #DD4A68}.token.regex,.token.important,.token.variable{color: #e90}.token.important,.token.bold{font-weight: bold}.token.italic{font-style: italic}.token.entity{cursor: help}');
     // Custom css to fix some layout problems because of the insertion of <code> element
-    styleArray.push('pre>code{border-radius:initial;display:initial;line-height:initial;margin-left:initial;overflow-y:initial;padding:initial}code,tt{background:initial;border:initial}.refract-container .deletion pre.source {background-color: #fff1f2 !important;} .refract-container .addition pre.source { background-color: #e8ffe8;}');
+    styleArray.push(`
+        pre > code {
+            border-radius: initial;
+            display: initial;
+            line-height: initial;
+            margin-left: initial;
+            overflow-y: initial;
+            padding: initial;
+        }
+        .refract-container .deletion pre.source {
+            background-color: #fff1f2 !important;
+        }
+        .refract-container .addition pre.source {
+            background-color: #e8ffe8;
+        }
+    `);
     style.innerHTML = styleArray.join('');
     head.insertBefore(style, lastHeadElement);
     head = null;


### PR DESCRIPTION
Fix for an issue where the styling necessary for syntax highlighting pull requests was interfering with some of Bitbucket's own styling, which caused inline code in comments to have a white background instead of their original gray background

Closes issue #74 and #93.
  
-------

**Before:**

![image](https://user-images.githubusercontent.com/7514993/34623415-b412570c-f227-11e7-8141-d81b3f893cf1.png)

**After:**

![image](https://user-images.githubusercontent.com/7514993/34623337-5b6e7fc2-f227-11e7-962e-acb76d134579.png)
