### PR TITLE
lang(jsx): replaced JS highlighting with JSX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 * **Collapse-diff**: Test suite for the feature, [pull request #94](https://github.com/refined-bitbucket/refined-bitbucket/pull/94).
 * **Syntax-highlighting**: Fix for an issue where the styling necessary for syntax highlighting pull requests was interfering with some of Bitbucket's own styling, which caused inline code in comments to have a white background instead of their original gray background, closes [issue #74](https://github.com/refined-bitbucket/refined-bitbucket/issues/74) and [issue #93](https://github.com/refined-bitbucket/refined-bitbucket/issues/93), [pull request #99](https://github.com/refined-bitbucket/refined-bitbucket/pull/99).
 
+### Language support:
+
+* Replaced `.js` syntax-highlighting styles from pure Javascript (`language-javascript`) to JSX (`language-jsx`). Highlighting should be exactly the same, except for JSX markup which will now be properly highlighted, [pull request #100](https://github.com/refined-bitbucket/refined-bitbucket/pull/100).
+
 # 3.2.0 (2017-12-13)
 
 The highlight of this release is the feature "Default merge strategy". [As you can see, this has been a popular request by Bitbucket users for almost a year now](https://bitbucket.org/site/master/issues/13895/default-merge-strategy), but now I hope this can serve as a solution for most of the people who voted on that official issue.

--- a/src/default-merge-strategy/index.js
+++ b/src/default-merge-strategy/index.js
@@ -32,7 +32,7 @@ function initAsync(defaultMergeStrategy) {
         if (!['merge_commit', 'squash'].includes(defaultMergeStrategy)) {
             const msg = `refined-bitbucket(default-merge-strategy): Unimplemented merge strategy '${defaultMergeStrategy}'. No action taken.`;
             // Only warn when in browser, not when testing
-            if (!process || !process.title) {
+            if (!process) {
                 console.warn(msg);
             }
             reject(msg);

--- a/src/syntax-highlight/language-ext.js
+++ b/src/syntax-highlight/language-ext.js
@@ -11,7 +11,7 @@ module.exports = {
     '.kt': 'language-kotlin',
     '.xml': 'language-markup',
     '.html': 'language-markup',
-    '.js': 'language-javascript',
+    '.js': 'language-jsx',
     '.styl': 'language-stylus',
     '.css': 'language-css',
     '.cs': 'language-csharp',

--- a/test/syntax-highlight.spec.js
+++ b/test/syntax-highlight.spec.js
@@ -33,7 +33,7 @@ test('should syntax-highlight diff', t => {
     );
 
     const expected = (
-        <section class="bb-udiff language-javascript" data-filename="filename.js">
+        <section class="bb-udiff language-jsx" data-filename="filename.js">
             <div class="heading">
                 <div class="diff-actions secondary" id="side-by-side-1">
                     <div class="aui-buttons">
@@ -43,7 +43,7 @@ test('should syntax-highlight diff', t => {
             </div>
 
             <div class="refract-content-container">
-                <pre class=" language-javascript">
+                <pre class=" language-jsx">
                     <span class="token keyword">var</span> msg <span class="token operator">=</span> <span class="token string">'Hello world'</span><span class="token punctuation">;</span>
                 </pre>
             </div>
@@ -68,11 +68,11 @@ test('should syntax-highlight when side-by-side button not present', t => {
     );
 
     const expected = (
-        <section class="bb-udiff language-javascript" data-filename="filename.js">
+        <section class="bb-udiff language-jsx" data-filename="filename.js">
             {/* no side-by-side button */}
 
             <div class="refract-content-container">
-                <pre class=" language-javascript">
+                <pre class=" language-jsx">
                     <span class="token keyword">var</span> msg <span class="token operator">=</span> <span class="token string">'Hello world'</span><span class="token punctuation">;</span>
                 </pre>
             </div>


### PR DESCRIPTION
Replaced `.js` syntax-highlighting styles from pure Javascript (`language-javascript`) to JSX (`language-jsx`).
Highlighting should be exactly the same, except for JSX markup which will now be properly highlighted.