### PR TITLE
feat(pr-template): Enable to include a PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ### Features:
 
+* **Pullrequest Template**: [Available in GitHub since the start of 2016](https://github.com/blog/2111-issue-and-pull-request-templates), and [actively requested by Bitbucket users](https://bitbucket.org/site/master/issues/11571/custom-pull-request-description-template). With this feature, by including a `PULL_REQUEST_TEMPLATE.md` file in the default branch of the repository in one of the locations below, the contents of that file template will replace the default pull request body inserted by Bitbucket when creating a new one.
+
+    ```
+    /PULL_REQUEST_TEMPLATE.md
+    /docs/PULL_REQUEST_TEMPLATE.md
+    /.github/PULL_REQUEST_TEMPLATE.md
+    /.bitbucket/PULL_REQUEST_TEMPLATE.md
+    ```
+
+    Please note that the filename IS case sensitive (must be all caps),
+    and MUST have the .md file extension. No other file extensions will be
+    recognized. The file to be used will be the first to be found in one
+    of these locations (from top to bottom).
+
+    It's also possible to specify a URL for a raw Gist with the contents
+    of the template in the options page, in case you don't want to include
+    the file in your repository, e.g., https://gist.githubusercontent.com/anonymous/8054a3ee32f7cf1a5975e3fd52b3c5f3/raw/f6897720e8b6b93becd246187dac36038291c3a4/PULL_REQUEST_TEMPLATE.md.
+
+    Closes [issue #105](https://github.com/refined-bitbucket/refined-bitbucket/issues/105), [pull request #106](https://github.com/refined-bitbucket/refined-bitbucket/pull/106).
+
 * **Autocollapse**: Add option to automatically collapse deleted files in a pull request, closes [issue #96](https://github.com/refined-bitbucket/refined-bitbucket/issues/96), [pull request #101](https://github.com/refined-bitbucket/refined-bitbucket/pull/101).
 
 ### Development:

--- a/README.md
+++ b/README.md
@@ -15,6 +15,23 @@ We all know BitBucket lacks some features that we have in other platforms like G
 - Pullrequest Ignore. Add filename patterns in the Options page that you would like the extension to completely remove when the Pull Request loads.
 - Button to load all failed diffs in Pull Request view.
 - Choose a default merge strategy for your pull requests.
+- Include a `PULL_REQUEST_TEMPLATE.md` file in the default branch of the repository in one of the locations below, and the contents of that file template will replace the default pull request body inserted by Bitbucket when creating a new one.
+
+    ```
+    /PULL_REQUEST_TEMPLATE.md
+    /docs/PULL_REQUEST_TEMPLATE.md
+    /.github/PULL_REQUEST_TEMPLATE.md
+    /.bitbucket/PULL_REQUEST_TEMPLATE.md
+    ```
+
+    Please note that the filename IS case sensitive (must be all caps),
+    and MUST have the .md file extension. No other file extensions will be
+    recognized. The file to be used will be the first to be found in one
+    of these locations (from top to bottom).
+
+    It's also possible to specify a URL for a raw Gist with the contents
+    of the template in the options page, in case you don't want to include
+    the file in your repository, e.g., https://gist.githubusercontent.com/anonymous/8054a3ee32f7cf1a5975e3fd52b3c5f3/raw/f6897720e8b6b93becd246187dac36038291c3a4/PULL_REQUEST_TEMPLATE.md.
 
 ## Some images
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5858,6 +5858,11 @@
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
       "dev": true
     },
+    "marked": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.12.tgz",
+      "integrity": "sha512-k4NaW+vS7ytQn6MgJn3fYpQt20/mOgYM5Ft9BYMfQJDz2QT6yEeS9XJ8k2Nw8JTeWK/znPPW2n3UJGzyYEiMoA=="
+    },
     "matcher": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "ignore": "^3.3.6",
     "jquery": "^3.2.1",
     "jquery-highlight": "^3.4.0",
+    "marked": "^0.3.12",
     "mousetrap": "^1.6.1",
     "selector-observer": "^1.1.0",
     "webext-options-sync": "^0.15.0"

--- a/src/main.js
+++ b/src/main.js
@@ -13,6 +13,8 @@ import loadAllDiffs from './load-all-diffs';
 import syntaxHighlight from './syntax-highlight';
 import ignoreWhitespace from './ignore-whitespace';
 import defaultMergeStrategy from './default-merge-strategy';
+import insertPullrequestTemplate from './pullrequest-template';
+import {isCreatePullRequestURL} from './page-detect';
 
 import 'selector-observer';
 
@@ -40,6 +42,10 @@ function init(config) {
 
     if (config.ignoreWhitespace) {
         ignoreWhitespace.init();
+    }
+
+    if (config.prTemplateEnabled && isCreatePullRequestURL()) {
+        insertPullrequestTemplate(config.prTemplateUrl);
     }
 
     defaultMergeStrategy.init(config.defaultMergeStrategy);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -21,6 +21,7 @@
   "permissions": [
     "activeTab",
     "https://bitbucket.org/*",
+    "https://gist.githubusercontent.com/*",
     "storage"
   ],
   "content_scripts": [

--- a/src/options.html
+++ b/src/options.html
@@ -44,6 +44,13 @@
         <br>
         <br>
 
+        <label>
+            <input type="checkbox" name="prTemplateEnabled"> Use a <em>PULL_REQUEST_TEMPLATE.md</em> from the repository when creating new pull requests or specify a URL with your own raw template (must be hosted publicly in <a href="http://gist.github.com/">http://gist.github.com/</a>). See the <a href="http://github.com/refined-bitbucket/refined-bitbucket">README</a> of the extension for more details on how this works.
+            <input type="text" name="prTemplateUrl" style="width: 100%;">
+        </label>
+        <br>
+        <br>
+
         <label> Default Merge Strategy </label>
         <div name="default-merge-strategy-form" style="margin: 0.5em 0 0 1em;">
             <input type="radio" name="defaultMergeStrategy" value="merge_commit" checked> Merge commit

--- a/src/page-detect.js
+++ b/src/page-detect.js
@@ -1,7 +1,9 @@
-// Some of this functions are borrowed from https://github.com/sindresorhus/refined-github/blob/master/src/libs/page-detect.js
+// Some of this functions are borrowed from https://github.com/sindresorhus/refined-github/blob/master/source/libs/page-detect.js
 
 // Drops leading and trailing slash to avoid /\/?/ everywhere
 const getCleanPathname = () => location.pathname.replace(/^[/]|[/]$/g, '');
+
+export const getRepoURL = () => location.pathname.slice(1).split('/', 2).join('/');
 
 // Parses a repo's subpage, e.g.
 // '/user/repo/pull-requests/' -> 'pull-requests'
@@ -15,3 +17,5 @@ const getRepoPath = () => {
 export const isPullRequestList = () => getRepoPath() === 'pull-requests';
 
 export const isPullRequest = () => getRepoPath().startsWith('pull-requests/');
+
+export const isCreatePullRequestURL = () => getRepoPath() === 'pull-requests/new';

--- a/src/pullrequest-template/index.js
+++ b/src/pullrequest-template/index.js
@@ -1,0 +1,1 @@
+export {default} from './pullrequest-template';

--- a/src/pullrequest-template/pullrequest-template.js
+++ b/src/pullrequest-template/pullrequest-template.js
@@ -1,0 +1,65 @@
+import elementReady from 'element-ready';
+import marked from 'marked';
+import {getRepoURL} from '../page-detect';
+
+export default function fetchAndInsertPullrequestTemplate(externalUrl) {
+    const pullrequestTemplateUrls = getPullrequestTemplateUrls();
+    if (externalUrl) {
+        pullrequestTemplateUrls.push(externalUrl);
+    }
+    const requests = pullrequestTemplateUrls.map(url =>
+        fetch(url, {credentials: 'include'})
+    );
+    insertPullrequestTemplate(requests);
+}
+
+export function getPullrequestTemplateUrls() {
+    const repoURL = getRepoURL();
+
+    const defaultBranch = (() => {
+        const branchSelectValue = document.querySelector('select[name="dest"]')
+            .value;
+        return branchSelectValue.substring(
+            branchSelectValue.lastIndexOf(':') + 1
+        );
+    })();
+
+    const pullrequestTemplateUrls = [
+        `/${repoURL}/raw/${defaultBranch}/PULL_REQUEST_TEMPLATE.md`,
+        `/${repoURL}/raw/${defaultBranch}/docs/PULL_REQUEST_TEMPLATE.md`,
+        `/${repoURL}/raw/${defaultBranch}/.github/PULL_REQUEST_TEMPLATE.md`,
+        `/${repoURL}/raw/${defaultBranch}/.bitbucket/PULL_REQUEST_TEMPLATE.md`
+    ];
+
+    return pullrequestTemplateUrls;
+}
+
+export async function insertPullrequestTemplate(requests) {
+    const responses = await Promise.all(requests);
+    const firstSuccessfulResponse = responses.find(response => response.ok);
+
+    if (!firstSuccessfulResponse) {
+        return;
+    }
+
+    const defaultEditor = elementReady('textarea[id="id_description"]');
+    const atlassianEditor = elementReady(
+        '#ak_editor_description div[contenteditable="true"]'
+    );
+    const editorPromises = [defaultEditor, atlassianEditor];
+    const editor = await Promise.race(editorPromises);
+    editorPromises.forEach(p => requestAnimationFrame(() => p.cancel()));
+
+    const md = await firstSuccessfulResponse.text();
+
+    if (editor instanceof HTMLTextAreaElement) {
+        editor.value = md;
+    } else if (editor instanceof HTMLDivElement) {
+        const html = marked(md);
+        editor.innerHTML = html;
+    } else {
+        console.warn(
+            'refined-bitbucket(pullrequest-template): Could not find pull request editor.'
+        );
+    }
+}

--- a/test/default-merge-strategy.spec.js
+++ b/test/default-merge-strategy.spec.js
@@ -4,16 +4,11 @@ import {h} from 'dom-chef';
 import delay from 'yoctodelay';
 
 import defaultMergeStrategy, {SCRIPT_ID, scriptAlreadyExists} from '../src/default-merge-strategy';
+import {cleanDocumentBody} from './test-utils';
 
 import './setup-jsdom';
 
 global.location = new URL('https://www.bitbucket.org');
-
-const cleanDocumentBody = () => {
-    while (document.body.hasChildNodes()) {
-        document.body.removeChild(document.body.lastChild);
-    }
-};
 
 test('should not try to choose default merge strategy on non-pull request pages', async t => {
     location.href = 'https://www.bitbucket.org/user/repo/is-not-a-pull-request';

--- a/test/pullrequest-template.spec.js
+++ b/test/pullrequest-template.spec.js
@@ -1,0 +1,96 @@
+import {URL} from 'url';
+import test from 'ava';
+import {h} from 'dom-chef';
+import delay from 'yoctodelay';
+import marked from 'marked';
+
+import {getPullrequestTemplateUrls, insertPullrequestTemplate} from '../src/pullrequest-template/pullrequest-template';
+import {cleanDocumentBody} from './test-utils';
+
+import './setup-jsdom';
+
+test('should get repo\'s pull request template urls', t => {
+    global.location = new URL(
+        'https://www.bitbucket.org/user/repo/pull-requests/new'
+    );
+
+    const branchSelect = (
+        <select data-placeholder="Select destination branch…" data-repo="user/repo" data-field="dest" class="branch-field select2-offscreen" tabindex="-1" name="dest">
+            <optgroup label="Branches">
+                <option value="user/repo:8e70157fd541:branch-1">branch-1</option>
+                <option value="user/repo:9140a9b18ec3:branch-2">branch-2</option>
+                <option selected="" data-mainbranch="true" value="user/repo:548a0cb7aa77:master">master</option>
+            </optgroup>
+        </select>
+    );
+
+    document.body.appendChild(branchSelect);
+
+    const expected = [
+        `/user/repo/raw/master/PULL_REQUEST_TEMPLATE.md`,
+        `/user/repo/raw/master/docs/PULL_REQUEST_TEMPLATE.md`,
+        `/user/repo/raw/master/.github/PULL_REQUEST_TEMPLATE.md`,
+        `/user/repo/raw/master/.bitbucket/PULL_REQUEST_TEMPLATE.md`
+    ];
+
+    const actual = getPullrequestTemplateUrls();
+
+    t.deepEqual(actual, expected);
+});
+
+test.serial('should not insert pull request templates if didn\'t find them', async t => {
+    const requests = Array.from(Array(4)).map(() => {
+        return new Promise(resolve => {
+            delay(100).then(() => resolve({ok: false}));
+        });
+    });
+
+    await insertPullrequestTemplate(requests);
+
+    t.is(document.body.innerHTML, '');
+});
+
+test.serial('should insert pull request template in default editor', async t => {
+    const templateContents = 'pull request template contents';
+    const requests = [
+        Promise.resolve({
+            ok: true,
+            text: () => Promise.resolve(templateContents)
+        })
+    ];
+
+    const defaultEditor = <textarea id="id_description" />;
+    delay(1000).then(() => document.body.appendChild(defaultEditor));
+
+    await insertPullrequestTemplate(requests);
+
+    t.is(defaultEditor.value, templateContents);
+
+    cleanDocumentBody();
+    await delay(16);
+});
+
+test.serial('should insert pull request template in Atlassian editor', async t => {
+    const templateContents = 'pull request template contents';
+    const requests = [
+        Promise.resolve({
+            ok: true,
+            text: () => Promise.resolve(templateContents)
+        })
+    ];
+
+    const atlassianEditor = (
+        <ak-editor-bitbucket id="ak_editor_description">
+            <div contenteditable="true"></div>
+        </ak-editor-bitbucket>
+    );
+    delay(1000).then(() => document.body.appendChild(atlassianEditor));
+
+    await insertPullrequestTemplate(requests);
+
+    const richTemplateContents = marked(templateContents);
+    t.is(atlassianEditor.firstChild.innerHTML, richTemplateContents);
+
+    cleanDocumentBody();
+    await delay(16);
+});

--- a/test/setup-jsdom.js
+++ b/test/setup-jsdom.js
@@ -7,6 +7,8 @@ global.window = dom.window;
 global.document = dom.window.document;
 global.Element = dom.window._core.Element;
 global.Text = dom.window._core.Text;
+global.HTMLTextAreaElement = dom.window._core.HTMLTextAreaElement;
+global.HTMLDivElement = dom.window._core.HTMLDivElement;
 global.requestAnimationFrame = fn => setTimeout(fn, 16);
 global.cancelAnimationFrame = id => clearTimeout(id);
 

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -1,0 +1,5 @@
+export const cleanDocumentBody = () => {
+    while (document.body.hasChildNodes()) {
+        document.body.removeChild(document.body.lastChild);
+    }
+};


### PR DESCRIPTION
By including this file in the repository in one of the locations below,
the contents of that file template will replace the default pull request body
inserted by Bitbucket when creating a new one.

```
/PULL_REQUEST_TEMPLATE.md
/docs/PULL_REQUEST_TEMPLATE.md
/.github/PULL_REQUEST_TEMPLATE.md
/.bitbucket/PULL_REQUEST_TEMPLATE.md
```

Please note that the filename IS case sensitive (must be all caps),
and MUST have the .md file extension. No other file extensions will be
recognized. The file to be used will be the first to be found in one
of these locations (from top to bottom).

It's also possible to specify a URL for a raw Gist with the contents
of the template in the options page, in case you don't want to include
the file in your repository, e.g., https://gist.githubusercontent.com/anonymous/8054a3ee32f7cf1a5975e3fd52b3c5f3/raw/f6897720e8b6b93becd246187dac36038291c3a4/PULL_REQUEST_TEMPLATE.md.

Closes issue #105.

![pullrequest-template](https://user-images.githubusercontent.com/7514993/35177767-ae91e0e0-fd58-11e7-8ca0-fc7f5222340d.gif)
