### PR TITLE
fix(build): setting `reduce_vars` to false in UglifyJSPlugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@
 * Prettier set up in development environment: npm scripts, commit hooks, editor integration,
   closes [issue #109](https://github.com/refined-bitbucket/refined-bitbucket/issues/109),
   [pull request #114](https://github.com/refined-bitbucket/refined-bitbucket/pull/114).
+* Fixed an bug with the production build process where the `UglifyJSPlugin` was outputting
+  a bundle with broken code, closes [issue #115](https://github.com/refined-bitbucket/refined-bitbucket/issues/115),
+  [pull request #116](https://github.com/refined-bitbucket/refined-bitbucket/pull/116).
 
 # 3.3.0 (2018-01-09)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -430,7 +430,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000793",
+        "caniuse-db": "1.0.30000794",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -1443,7 +1443,7 @@
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000793",
+        "caniuse-db": "1.0.30000794",
         "electron-to-chromium": "1.3.31"
       }
     },
@@ -1598,15 +1598,15 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000793",
+        "caniuse-db": "1.0.30000794",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000793",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000793.tgz",
-      "integrity": "sha1-PADGbkI6ehkHx92Wdpp4sq+opy4=",
+      "version": "1.0.30000794",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000794.tgz",
+      "integrity": "sha1-u+cRBPonfOSzYjh9VJBei4jlLzU=",
       "dev": true
     },
     "capture-stack-trace": {
@@ -4687,9 +4687,9 @@
       }
     },
     "js-base64": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.1.tgz",
-      "integrity": "sha512-2h586r2I/CqU7z1aa1kBgWaVAXWAZK+zHnceGi/jFgn7+7VSluxYer/i3xOZVearCxxXvyDkLtTBo+OeJCA3kA==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.2.tgz",
+      "integrity": "sha512-lLkz3IRPTNeATsKQGeltbzRK/5+bWsXBHfpZrxJAi4N30RtCtNA+rJznp4uR2+4OgkBsoeeFwONVLr4gzIVErQ==",
       "dev": true
     },
     "js-string-escape": {
@@ -6516,7 +6516,7 @@
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
-        "js-base64": "2.4.1",
+        "js-base64": "2.4.2",
         "source-map": "0.5.7",
         "supports-color": "3.2.3"
       },
@@ -7129,13 +7129,13 @@
       "requires": {
         "duplexify": "3.5.3",
         "inherits": "2.0.3",
-        "pump": "2.0.0"
+        "pump": "2.0.1"
       },
       "dependencies": {
         "pump": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.0.tgz",
-          "integrity": "sha512-6MYypjOvtiXhBSTOD0Zs5eNjCGfnqi5mPsCsW+dgKTxrZzQMZQNpBo3XRkLx7id753f3EeyHLBqzqqUymIolgw==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
           "dev": true,
           "requires": {
             "end-of-stream": "1.4.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -58,6 +58,17 @@ if (process.env.NODE_ENV === 'production') {
                 mangle: true,
                 output: {
                     beautify: false
+                },
+                compress: {
+                    // https://github.com/refined-bitbucket/refined-bitbucket/issues/115
+                    // https://github.com/refined-bitbucket/refined-bitbucket/pull/116
+                    // The default value of this option was producing a bundle
+                    // with broken code due to a constant variable reassignment
+                    // that ended up causing a TypeError at runtime.
+                    // See the issue and the pull request for more details.
+                    // (default: true) -- Improve optimization on variables assigned with and used as constant values.
+                    // eslint-disable-next-line camelcase
+                    reduce_vars: false
                 }
             }
         })


### PR DESCRIPTION
The default value of this option (`true`) was producing a bundle
with broken code due to a constant variable reassignment
that ended up causing a TypeError at runtime.

See the issue and the pull request for more details.

Closes issue #115.

---------

This was a very interesting case to solve, but incredibly frustrating. Turns out that this was introduced in c06de4d1e0efe769c8d13d63a0dc1aa2d4176fa5 because the `package-lock.json` file was completely regenerated in that commit, and the resulting dependency graph was using a different version of `uglifyjs-webpack-plugin`, which apparently had some changes that produced this bug.

What's even more interesting is that in my digging I found that if we do this as far back as tag v3.0.0 (which was the first version with the webpack build), the bug happens here too, even when I specified the webpack and `uglifyjs-webpack-plugin` versions originally used at that time. So basically, if you go back in time to any point in the repository history that has a webpack build, delete the lock file, and try to rebuild the production bundle with a freshly installed `node_modules`, you will get uglified bundle with the broken code.

In the end this didn't turn out to be very relevant for the actual solution, but helped in isolating where the issue might've been happening and ruling out other possibilities.

What solved it was setting the `reduce_vars` option of the `compress` settings to `false` in the `UglifyJSPlugin` constructor.

```diff
new UglifyJSPlugin({
    sourceMap: false,
    uglifyOptions: {
        mangle: true,
        output: {
            beautify: false
        },
+       compress: {
+           reduce_vars: false
+       }
    }
})
```

Here's the output bundle before (the same that was included in the description of issue #115):

```js
"use strict";
const r = n(14), i = n(15), o = /acit|ex(?:s|g|n|p|$)|rph|ows|mnc|ntw|ine[ch]|zoo|^ord/i, s = [ "a", "audio", "canvas", "iframe", "script", "video" ], a = r.filter(e => -1 === s.indexOf(e)), l = e => (e => a.indexOf(e) >= 0)(e) ? document.createElementNS("http://www.w3.org/2000/svg", e) : document.createElement(e), u = (e, t, n) => {
    /^xlink[AHRST]/.test(t) ? e.setAttributeNS("http://www.w3.org/1999/xlink", t, n) : e.setAttribute(t, n);
}, c = (e, t, n) => {
    const r = l(e);
    return Object.keys(t).forEach(e => {
        const n = t[e];
        if ("class" === e || "className" === e) u(r, "class", n); else if ("style" === e) r = r, 
        p = n, Object.keys(p).forEach(e => {
            let t = p[e];
            "number" != typeof t || o.test(e) || (t += "px"), r.style.setProperty(e, t);
        }); else if (0 === e.indexOf("on")) {
            const t = e.substr(2).toLowerCase();
            r.addEventListener(t, n);
        } else "dangerouslySetInnerHTML" === e ? r.innerHTML = n.__html : "key" !== e && u(r, e, n);
    }), t.dangerouslySetInnerHTML || r.appendChild(n), r;
};
var f, p;
t.h = function(e, t) {
    const n = [].slice.apply(arguments, [ 2 ]), r = document.createDocumentFragment();
    return i(n).forEach(e => {
        e instanceof Element ? r.appendChild(e) : "boolean" != typeof e && null !== e && r.appendChild(document.createTextNode(e));
    }), c(e, t || {}, r);
};
```

... and here it is after changing the `reduce_vars` option:

```js
"use strict";
const r = n(14), i = n(15), o = /acit|ex(?:s|g|n|p|$)|rph|ows|mnc|ntw|ine[ch]|zoo|^ord/i, s = [ "a", "audio", "canvas", "iframe", "script", "video" ], a = r.filter(e => -1 === s.indexOf(e)), l = e => a.indexOf(e) >= 0, u = (e, t) => {
    Object.keys(t).forEach(n => {
        let r = t[n];
        "number" != typeof r || o.test(n) || (r += "px"), e.style.setProperty(n, r);
    });
}, c = e => l(e) ? document.createElementNS("http://www.w3.org/2000/svg", e) : document.createElement(e), f = (e, t, n) => {
    /^xlink[AHRST]/.test(t) ? e.setAttributeNS("http://www.w3.org/1999/xlink", t, n) : e.setAttribute(t, n);
}, p = (e, t, n) => {
    const r = c(e);
    return Object.keys(t).forEach(e => {
        const n = t[e];
        if ("class" === e || "className" === e) f(r, "class", n); else if ("style" === e) u(r, n); else if (0 === e.indexOf("on")) {
            const t = e.substr(2).toLowerCase();
            r.addEventListener(t, n);
        } else "dangerouslySetInnerHTML" === e ? r.innerHTML = n.__html : "key" !== e && f(r, e, n);
    }), t.dangerouslySetInnerHTML || r.appendChild(n), r;
};
function d(e, t) {
    const n = [].slice.apply(arguments, [ 2 ]), r = document.createDocumentFragment();
    return i(n).forEach(e => {
        e instanceof Element ? r.appendChild(e) : "boolean" != typeof e && null !== e && r.appendChild(document.createTextNode(e));
    }), p(e, t || {}, r);
}
t.h = d;
```

As you can see, the `else if ("style" === e)` branch of the code is not reassigning anything anymore, and the issue goes away.