### PR TITLE
fix(pr-template): remove https://gist.githubusercontent.com/ permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Next Version
+
+### Improvement:
+
+* **Pullrequest Template**: Permission to access https://gist.githubusercontent.com/ is no longer necessary, closes [issue #119](https://github.com/refined-bitbucket/refined-bitbucket/issues/119), [pull request #120](https://github.com/refined-bitbucket/refined-bitbucket/pull/120).
+
+### Language support:
+
+* **ColdFusion Markup Language**: Added cfml (\*.cfc/\*.cfm) extension support, [pull request #118](https://github.com/refined-bitbucket/refined-bitbucket/pull/118).
+
 # 3.4.0 (2018-01-23)
 
 ### Features:

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -21,7 +21,6 @@
   "permissions": [
     "activeTab",
     "https://bitbucket.org/*",
-    "https://gist.githubusercontent.com/*",
     "storage"
   ],
   "content_scripts": [

--- a/src/pullrequest-template/pullrequest-template.js
+++ b/src/pullrequest-template/pullrequest-template.js
@@ -4,12 +4,12 @@ import { getRepoURL } from '../page-detect';
 
 export default function fetchAndInsertPullrequestTemplate(externalUrl) {
     const pullrequestTemplateUrls = getPullrequestTemplateUrls();
-    if (externalUrl) {
-        pullrequestTemplateUrls.push(externalUrl);
-    }
     const requests = pullrequestTemplateUrls.map(url =>
         fetch(url, { credentials: 'include' })
     );
+    if (externalUrl) {
+        requests.push(fetch(externalUrl));
+    }
     insertPullrequestTemplate(requests);
 }
 


### PR DESCRIPTION
Permission to access https://gist.githubusercontent.com/ is no longer necessary.

Closes issue #119.