### PR TITLE
Add .hpp extension for language-cpp

### DIFF
--- a/src/syntax-highlight/language-ext.js
+++ b/src/syntax-highlight/language-ext.js
@@ -24,6 +24,7 @@ module.exports = {
     '.c': 'language-c',
     '.cpp': 'language-cpp',
     '.cc': 'language-cpp',
+    '.hpp': 'language-cpp',
     '.coffee': 'language-coffeescript',
     '.dart': 'language-dart',
     '.ex': 'language-elixir',


### PR DESCRIPTION
.hpp It is commonly used for template implementations, or directly as C++ header extension.