### PR TITLE
feat(sidebar-counters): add counters to nav menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,16 @@
+# Next Version
+
+### Features:
+
+* **Sidebar Counters**: Adds counters of the open or active "Branches" and "Pull requests"
+  links in the sidebar navigation menu, closes [issue #133](https://github.com/refined-bitbucket/refined-bitbucket/issues/133),
+  [pull request #134](https://github.com/refined-bitbucket/refined-bitbucket/pull/134).
+
 # 3.5.0 (2018-02-01)
 
 ### Features:
 
-* Improve the default font-family and size of lines of code in Source view, closes [issue #35](https://github.com/refined-bitbucket/refined-bitbucket/issues/121), [pull request #126](https://github.com/refined-bitbucket/refined-bitbucket/pull/126).
+* Improve the default font-family and size of lines of code in Source view, closes [issue #35](https://github.com/refined-bitbucket/refined-bitbucket/issues/35), [pull request #126](https://github.com/refined-bitbucket/refined-bitbucket/pull/126).
 
 ### Language support:
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ We all know BitBucket lacks some features that we have in other platforms like G
     * Add filename patterns in the Options page that you would like the extension to collapse automatically when the pull request or commit loads.
     * Deleted files are automatically collapsed.
 * Diff Ignore. Add filename patterns in the Options page that you would like the extension to completely remove when the pull request or commit loads.
+* Counters for open or active branches and pull requests in the sidebar navigation menu.
 * Button to load all failed diffs in pull request and commit view.
 * Choose a default merge strategy for your pull requests.
 * Check the "Close anchor branch" checkbox by default when creating or editing pull requests.
@@ -62,7 +63,7 @@ We all know BitBucket lacks some features that we have in other platforms like G
 			The Options page.<br>
 		</th>
 		<th width="50%">
-			<em>pullrequest-ignore</em> and <em>load-all-diffs</em>
+			<em>Diff ignore</em> and <em>Load all diffs</em>
 		</th>
 	</tr>
 	<tr>
@@ -70,13 +71,13 @@ We all know BitBucket lacks some features that we have in other platforms like G
 			<img src="https://user-images.githubusercontent.com/7514993/33744735-1f66115c-db89-11e7-804c-9739d3619c65.png" alt="options">
 		</td>
 		<td>
-			<strong>pullrequest-ignore</strong><br>
+			<strong>Diff ignore</strong><br>
 			<img src="https://user-images.githubusercontent.com/7514993/32203543-36e1b012-bdba-11e7-8a26-4accd0e775b6.png" alt="pullrequest-ignore">
 		</td>
 	</tr>
 	<tr>
 		<td>
-			<strong>load-all-diffs</strong><br>
+			<strong>Load all diffs</strong><br>
 			<img src="https://user-images.githubusercontent.com/7514993/32376684-da306e0c-c07b-11e7-81e6-bb9c42d21d2e.gif" alt="load-all-diffs">
 		</td>
 	</tr>
@@ -98,6 +99,24 @@ We all know BitBucket lacks some features that we have in other platforms like G
 		</td>
 		<td>
 			<img src="https://user-images.githubusercontent.com/7514993/30448047-a815dd4a-995b-11e7-98e5-48664c2bd587.gif" alt="occurrences-highlighter">
+		</td>
+	</tr>
+</table>
+
+<table>
+	<tr>
+		<th colspan="2">
+			Sidebar counters
+		</th>
+	</tr>
+	<tr>
+		<td>
+			<img src="https://user-images.githubusercontent.com/7514993/35759127-0f886b44-084e-11e8-9e3a-58e9ce3da71a.png" alt="expanded"/> <br />
+			Expanded
+		</td>
+		<td>
+			<img src="https://user-images.githubusercontent.com/7514993/35742830-1c604af8-0812-11e8-936b-f6083599fb45.png" alt="collapsed" /> <br />
+			Collapsed
 		</td>
 	</tr>
 </table>

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,9 +87,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.3.0.tgz",
-      "integrity": "sha512-Yej+zOJ1Dm/IMZzzj78OntP/r3zHEaKcyNoU2lAaxPtrseM6rF0xwqoz5Q5ysAiED9hTjI2hgtvLXitlCN1/Ug==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
+      "integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ==",
       "dev": true
     },
     "acorn-dynamic-import": {
@@ -115,7 +115,7 @@
       "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
       "dev": true,
       "requires": {
-        "acorn": "5.3.0"
+        "acorn": "5.4.1"
       }
     },
     "acorn-jsx": {
@@ -398,7 +398,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000794",
+        "caniuse-db": "1.0.30000800",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -485,7 +485,7 @@
         "safe-buffer": "5.1.1",
         "semver": "5.5.0",
         "slash": "1.0.0",
-        "source-map-support": "0.5.2",
+        "source-map-support": "0.5.3",
         "stack-utils": "1.0.1",
         "strip-ansi": "4.0.0",
         "strip-bom-buf": "1.0.0",
@@ -1267,8 +1267,8 @@
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000794",
-        "electron-to-chromium": "1.3.31"
+        "caniuse-db": "1.0.30000800",
+        "electron-to-chromium": "1.3.32"
       }
     },
     "buf-compare": {
@@ -1323,7 +1323,7 @@
         "glob": "7.1.2",
         "graceful-fs": "4.1.11",
         "lru-cache": "4.1.1",
-        "mississippi": "1.3.0",
+        "mississippi": "1.3.1",
         "mkdirp": "0.5.1",
         "move-concurrently": "1.0.1",
         "promise-inflight": "1.0.1",
@@ -1422,15 +1422,15 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000794",
+        "caniuse-db": "1.0.30000800",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000794",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000794.tgz",
-      "integrity": "sha1-u+cRBPonfOSzYjh9VJBei4jlLzU=",
+      "version": "1.0.30000800",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000800.tgz",
+      "integrity": "sha1-qG5rwjvZpwfV30LzPmTQSVz9ohg=",
       "dev": true
     },
     "capture-stack-trace": {
@@ -1485,6 +1485,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
+        "fsevents": "1.1.3",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -2486,9 +2487,9 @@
       }
     },
     "domain-browser": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
-      "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
+      "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
       "dev": true
     },
     "domexception": {
@@ -2569,9 +2570,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.31",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.31.tgz",
-      "integrity": "sha512-XE4CLbswkZgZFn34cKFy1xaX+F5LHxeDLjY1+rsK9asDzknhbrd9g/n/01/acbU25KTsUSiLKwvlLyA+6XLUOA==",
+      "version": "1.3.32",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.32.tgz",
+      "integrity": "sha1-EdBoTAhA4APEvoko+KxfNdvCtOY=",
       "dev": true
     },
     "elegant-spinner": {
@@ -3184,7 +3185,7 @@
       "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
       "dev": true,
       "requires": {
-        "acorn": "5.3.0",
+        "acorn": "5.4.1",
         "acorn-jsx": "3.0.1"
       }
     },
@@ -3594,6 +3595,910 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "fsevents": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "2.8.0",
+        "node-pre-gyp": "0.6.39"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
+          }
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true,
+          "dev": true
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true,
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "bundled": true,
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.39",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.2",
+            "hawk": "3.1.3",
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true,
+          "dev": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "sshpk": {
+          "version": "1.13.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
+        },
+        "tar-pack": {
+          "version": "3.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        }
+      }
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -3990,13 +4895,13 @@
       "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.16"
+        "postcss": "6.0.17"
       },
       "dependencies": {
         "postcss": {
-          "version": "6.0.16",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
-          "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
+          "version": "6.0.17",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+          "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
@@ -4446,7 +5351,7 @@
       "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
       "dev": true,
       "requires": {
-        "symbol-observable": "1.1.0"
+        "symbol-observable": "1.2.0"
       }
     },
     "is-path-cwd": {
@@ -4668,9 +5573,9 @@
       }
     },
     "js-base64": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.2.tgz",
-      "integrity": "sha512-lLkz3IRPTNeATsKQGeltbzRK/5+bWsXBHfpZrxJAi4N30RtCtNA+rJznp4uR2+4OgkBsoeeFwONVLr4gzIVErQ==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
+      "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw==",
       "dev": true
     },
     "js-string-escape": {
@@ -4709,13 +5614,13 @@
       "optional": true
     },
     "jsdom": {
-      "version": "11.6.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.6.0.tgz",
-      "integrity": "sha512-4lMxDCiQYK7qfVi9fKhDf2PpvXXeH/KAmcH6o0Ga7fApi8+lTBxRqGHWZ9B11SsK/pxQKOtsw413utw0M+hUrg==",
+      "version": "11.6.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.6.2.tgz",
+      "integrity": "sha512-pAeZhpbSlUp5yQcS6cBQJwkbzmv4tWFaYxHbFVSxzXefqjvtRA851Z5N2P+TguVG9YeUDcgb8pdeVQRJh0XR3Q==",
       "dev": true,
       "requires": {
         "abab": "1.0.4",
-        "acorn": "5.3.0",
+        "acorn": "5.4.1",
         "acorn-globals": "4.1.0",
         "array-equal": "1.0.0",
         "browser-process-hrtime": "0.1.2",
@@ -4924,9 +5829,9 @@
       }
     },
     "lint-staged": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-6.0.1.tgz",
-      "integrity": "sha512-GZnFshBzIpJMHO5aSqXGVJh5G1agKTrKGQOs6cTKA6a62PvZ7l2RawbpOrFdzjzkezxm7+LpKeleNt83gd9yRA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-6.1.0.tgz",
+      "integrity": "sha512-RMB6BUd2bEKaPnj06F7j8RRB8OHM+UP4fQS2LT8lF+X9BjSaezw1oVB5hc4elLhYvzlFCkhAaatzYz+x53YHgw==",
       "dev": true,
       "requires": {
         "app-root-path": "2.0.1",
@@ -5699,7 +6604,7 @@
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.1.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "memory-fs": {
@@ -5891,9 +6796,9 @@
       }
     },
     "mimic-fn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
     "minimalistic-assert": {
@@ -5924,9 +6829,9 @@
       "dev": true
     },
     "mississippi": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.0.tgz",
-      "integrity": "sha1-0gFYPrEjJ+PFwWQqQEqcrPlONPU=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.1.tgz",
+      "integrity": "sha512-/6rB8YXFbAtsUVRphIRQqB0+9c7VaPHCjVtvto+JqwVxgz8Zz+I+f68/JgQ+Pb4VlZb2svA9OtdXnHHsZz7ltg==",
       "dev": true,
       "requires": {
         "concat-stream": "1.6.0",
@@ -6005,6 +6910,13 @@
       "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
       "dev": true
     },
+    "nan": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
+      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
+      "dev": true,
+      "optional": true
+    },
     "node-libs-browser": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
@@ -6017,7 +6929,7 @@
         "console-browserify": "1.1.0",
         "constants-browserify": "1.0.0",
         "crypto-browserify": "3.12.0",
-        "domain-browser": "1.1.7",
+        "domain-browser": "1.2.0",
         "events": "1.1.1",
         "https-browserify": "1.0.0",
         "os-browserify": "0.3.0",
@@ -6029,7 +6941,7 @@
         "stream-browserify": "2.0.1",
         "stream-http": "2.8.0",
         "string_decoder": "1.0.3",
-        "timers-browserify": "2.0.4",
+        "timers-browserify": "2.0.6",
         "tty-browserify": "0.0.0",
         "url": "0.11.0",
         "util": "0.10.3",
@@ -6247,7 +7159,7 @@
       "dev": true,
       "requires": {
         "is-observable": "0.2.0",
-        "symbol-observable": "1.1.0"
+        "symbol-observable": "1.2.0"
       },
       "dependencies": {
         "is-observable": {
@@ -6284,7 +7196,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.1.0"
+        "mimic-fn": "1.2.0"
       }
     },
     "option-chain": {
@@ -6485,7 +7397,7 @@
       "dev": true,
       "requires": {
         "got": "6.7.1",
-        "registry-auth-token": "3.3.1",
+        "registry-auth-token": "3.3.2",
         "registry-url": "3.1.0",
         "semver": "5.5.0"
       }
@@ -6779,7 +7691,7 @@
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
-        "js-base64": "2.4.2",
+        "js-base64": "2.4.3",
         "source-map": "0.5.7",
         "supports-color": "3.2.3"
       },
@@ -7015,13 +7927,13 @@
       "integrity": "sha1-ZhQOzs447wa/DT41XWm/WdFB6oU=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.16"
+        "postcss": "6.0.17"
       },
       "dependencies": {
         "postcss": {
-          "version": "6.0.16",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
-          "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
+          "version": "6.0.17",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+          "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
@@ -7044,13 +7956,13 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.16"
+        "postcss": "6.0.17"
       },
       "dependencies": {
         "postcss": {
-          "version": "6.0.16",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
-          "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
+          "version": "6.0.17",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+          "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
@@ -7073,13 +7985,13 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.16"
+        "postcss": "6.0.17"
       },
       "dependencies": {
         "postcss": {
-          "version": "6.0.16",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
-          "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
+          "version": "6.0.17",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+          "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
@@ -7102,13 +8014,13 @@
       "dev": true,
       "requires": {
         "icss-replace-symbols": "1.1.0",
-        "postcss": "6.0.16"
+        "postcss": "6.0.17"
       },
       "dependencies": {
         "postcss": {
-          "version": "6.0.16",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
-          "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
+          "version": "6.0.17",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
+          "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
@@ -7492,9 +8404,9 @@
       }
     },
     "rc": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.4.tgz",
-      "integrity": "sha1-oPYGyq4qO4YrvQ74VILAElsxX6M=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.5.tgz",
+      "integrity": "sha1-J1zWh/bjs2zHVrqibf7oCnkDAf0=",
       "dev": true,
       "requires": {
         "deep-extend": "0.4.2",
@@ -7698,12 +8610,12 @@
       }
     },
     "registry-auth-token": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
-      "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+      "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
       "dev": true,
       "requires": {
-        "rc": "1.2.4",
+        "rc": "1.2.5",
         "safe-buffer": "5.1.1"
       }
     },
@@ -7713,7 +8625,7 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "1.2.4"
+        "rc": "1.2.5"
       }
     },
     "regjsgen": {
@@ -8146,9 +9058,9 @@
       "dev": true
     },
     "source-map-support": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.2.tgz",
-      "integrity": "sha512-9zHceZbQwERaMK1MiFguvx1dL9GQPLXInr2D/wUxAsuV6ZKc9F0DHYWeloMcalkYRbtanwqUakoDjvj55cL/4A==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.3.tgz",
+      "integrity": "sha512-eKkTgWYeBOQqFGXRfKabMFdnWepo51vWqEdoeikaEPFiJC7MCU5j2h4+6Q8npkZTeLGbSyecZvRxiSoWl3rh+w==",
       "dev": true,
       "requires": {
         "source-map": "0.6.1"
@@ -8304,15 +9216,6 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -8332,6 +9235,15 @@
         "define-properties": "1.1.2",
         "es-abstract": "1.10.0",
         "function-bind": "1.1.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringify-object": {
@@ -8486,9 +9398,9 @@
       "dev": true
     },
     "symbol-observable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.1.0.tgz",
-      "integrity": "sha512-dQoid9tqQ+uotGhuTKEY11X4xhyYePVnqGSoSm3OGKh2E8LZ6RPULp1uXTctk33IeERlrRJYoVSBglsL05F5Uw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
       "dev": true
     },
     "symbol-tree": {
@@ -8683,9 +9595,9 @@
       "dev": true
     },
     "timers-browserify": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.4.tgz",
-      "integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.6.tgz",
+      "integrity": "sha512-HQ3nbYRAowdVd0ckGFvmJPPCOH/CHleFN/Y0YQCX1DVaB7t+KFvisuyN09fuP8Jtp1CpfSh8O8bMkHbdbPe6Pw==",
       "dev": true,
       "requires": {
         "setimmediate": "1.0.5"
@@ -8794,9 +9706,9 @@
       "dev": true
     },
     "uglify-es": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.8.tgz",
-      "integrity": "sha512-j8li0jWcAN6yBuAVYFZEFyYINZAm4WEdMwkA6qXFi4TLrze3Mp0Le7QjW6LR9HQjQJ2zRa9VgnFLs3PatijWOw==",
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
+      "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
       "dev": true,
       "requires": {
         "commander": "2.13.0",
@@ -8819,9 +9731,9 @@
       "optional": true
     },
     "uglifyjs-webpack-plugin": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.1.6.tgz",
-      "integrity": "sha512-VUja+7rYbznEvUaeb8IxOCTUrq4BCb1ml0vffa+mfwKtrAwlqnU0ENF14DtYltV1cxd/HSuK51CCA/D/8kMQVw==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.1.8.tgz",
+      "integrity": "sha512-XG8/QmR1pyPeE1kj2aigo5kos8umefB31zW+PMvAAytHSB0T/vQvN6sqt8+Sh+y0b0A7zlmxNi2dzRnj0wcqGA==",
       "dev": true,
       "requires": {
         "cacache": "10.0.2",
@@ -8829,7 +9741,7 @@
         "schema-utils": "0.4.3",
         "serialize-javascript": "1.4.0",
         "source-map": "0.6.1",
-        "uglify-es": "3.3.8",
+        "uglify-es": "3.3.9",
         "webpack-sources": "1.1.0",
         "worker-farm": "1.5.2"
       },
@@ -9084,7 +9996,7 @@
       "integrity": "sha512-fxxKXoicjdXNUMY7LIdY89tkJJJ0m1Oo8PQutZ5rLgWbV5QVKI15Cn7+/IHnRTd3vfKfiwBx6SBqlorAuNA8LA==",
       "dev": true,
       "requires": {
-        "acorn": "5.3.0",
+        "acorn": "5.4.1",
         "acorn-dynamic-import": "2.0.2",
         "ajv": "5.5.2",
         "ajv-keywords": "2.1.1",
@@ -9596,7 +10508,7 @@
           "dev": true,
           "requires": {
             "got": "5.7.1",
-            "registry-auth-token": "3.3.1",
+            "registry-auth-token": "3.3.2",
             "registry-url": "3.1.0",
             "semver": "5.5.0"
           }

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "source": ["src/**/*.js"],
     "require": ["babel-register", "./scripts/ignore-utils"],
     "babel": "inherit",
-    "timeout": "5s"
+    "timeout": "10s"
   },
   "babel": {
     "presets": ["@ava/stage-4"],

--- a/src/background.js
+++ b/src/background.js
@@ -26,6 +26,7 @@ chrome.storage.sync.get(null, deprecatedOptions => {
             loadAllDiffs: true,
             closeAnchorBranch: true,
             improveFonts: true,
+            addSidebarCounters: true,
             prTemplateEnabled: true,
             defaultMergeStrategy: 'merge_commit',
             autocollapsePaths: ['package-lock.json', 'yarn.lock'],

--- a/src/default-merge-strategy/default-merge-strategy.js
+++ b/src/default-merge-strategy/default-merge-strategy.js
@@ -1,5 +1,6 @@
 import elementReady from 'element-ready';
 import { h } from 'dom-chef';
+import logger from '../logger';
 import { isPullRequest } from '../page-detect';
 
 export const SCRIPT_ID = 'refined_bitbucket_default_merge_script';
@@ -29,10 +30,7 @@ export function initAsync(defaultMergeStrategy) {
         // defaultMergeStrategy can be either 'merge_commit' or 'squash'
         if (!['merge_commit', 'squash'].includes(defaultMergeStrategy)) {
             const msg = `refined-bitbucket(default-merge-strategy): Unimplemented merge strategy '${defaultMergeStrategy}'. No action taken.`;
-            // Only warn when in browser, not when testing
-            if (!process) {
-                console.warn(msg);
-            }
+            logger.warn(msg);
             reject(msg);
         }
 

--- a/src/get-api-token.js
+++ b/src/get-api-token.js
@@ -1,0 +1,8 @@
+const getApiToken = () => {
+    const apiTokenContent = document.querySelector('meta[name="apitoken"]')
+        .content;
+    const parsedApiTokenContent = JSON.parse(apiTokenContent);
+    return parsedApiTokenContent.token;
+};
+
+export default getApiToken;

--- a/src/ignore-whitespace/ignore-whitespace.spec.js
+++ b/src/ignore-whitespace/ignore-whitespace.spec.js
@@ -1,14 +1,9 @@
-import { URL, URLSearchParams } from 'url';
 import { h } from 'dom-chef';
 import test from 'ava';
 
 import ignoreWhitespace from '.';
 
 import '../../test/setup-jsdom';
-
-global.URL = URL;
-global.URLSearchParams = URLSearchParams;
-global.location = new URL('https://www.bitbucket.org');
 
 test('should transform pull request link to add ignore whitespace query param to 1', t => {
     const actual = (

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,12 @@
+const logger = {};
+
+Object.keys(console).forEach(method => {
+    logger[method] = (...args) => {
+        // Only warn when in browser, not when testing
+        if (!process) {
+            console[method](...args);
+        }
+    };
+});
+
+export default logger;

--- a/src/main.js
+++ b/src/main.js
@@ -14,6 +14,7 @@ import loadAllDiffs from './load-all-diffs';
 import occurrencesHighlighter from './occurrences-highlighter';
 import insertPullrequestTemplate from './pullrequest-template';
 import syntaxHighlight from './syntax-highlight';
+import addSidebarCounters from './sidebar-counters';
 
 import waitForPullRequestContents from './wait-for-pullrequest';
 import {
@@ -62,6 +63,10 @@ function init(config) {
 
     if (config.improveFonts) {
         require('./improve-fonts.css');
+    }
+
+    if (config.addSidebarCounters) {
+        addSidebarCounters();
     }
 }
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -25,12 +25,19 @@
   ],
   "content_scripts": [
     {
-      "js": ["prism.js", "main.js"],
-      "matches": ["https://bitbucket.org/*"]
+      "js": [
+        "prism.js",
+        "main.js"
+      ],
+      "matches": [
+        "https://bitbucket.org/*"
+      ]
     }
   ],
   "background": {
-    "scripts": ["background.js"],
+    "scripts": [
+      "background.js"
+    ],
     "persistent": false
   }
 }

--- a/src/options.html
+++ b/src/options.html
@@ -57,6 +57,12 @@
         <br>
 
         <label>
+            <input type="checkbox" name="addSidebarCounters"> Add counters to the "Branches" and "Pull requests" links in the navigation sidebar menu.
+        </label>
+        <br>
+        <br>
+
+        <label>
             <input type="checkbox" name="prTemplateEnabled"> Use a
             <em>PULL_REQUEST_TEMPLATE.md</em> from the repository when creating new pull requests or specify a URL with your
             own raw template (must be hosted publicly in

--- a/src/page-detect.js
+++ b/src/page-detect.js
@@ -3,6 +3,7 @@
 // Drops leading and trailing slash to avoid /\/?/ everywhere
 const getCleanPathname = () => location.pathname.replace(/^[/]|[/]$/g, '');
 
+// '/user/repo/.../...' -> 'user/repo'
 export const getRepoURL = () =>
     location.pathname
         .slice(1)

--- a/src/sidebar-counters/index.js
+++ b/src/sidebar-counters/index.js
@@ -1,0 +1,1 @@
+export { default } from './sidebar-counters';

--- a/src/sidebar-counters/sidebar-counters.css
+++ b/src/sidebar-counters/sidebar-counters.css
@@ -1,0 +1,16 @@
+.__rbb-badge {
+    position: absolute;
+    right: 4px;
+}
+
+.__rbb-badge-counter {
+    font-weight: 650;
+    font-size: 10px;
+    border-radius: 50%;
+    height: 100%;
+    width: 100%;
+    box-sizing: border-box;
+    align-content: center;
+    align-items: center;
+    padding: 2px;
+}

--- a/src/sidebar-counters/sidebar-counters.js
+++ b/src/sidebar-counters/sidebar-counters.js
@@ -1,0 +1,76 @@
+import { h } from 'dom-chef';
+
+import getApiToken from '../get-api-token';
+import logger from '../logger';
+import { getRepoURL } from '../page-detect';
+
+import './sidebar-counters.css';
+
+const baseApiUrl = 'https://api.bitbucket.org/2.0/repositories';
+
+export const getResourcesCount = async url => {
+    const token = getApiToken();
+    const response = await fetch(url, {
+        headers: new Headers({
+            Authorization: `Bearer ${token}`
+        })
+    });
+
+    const resources = await response.json();
+    if (resources.error) {
+        logger.error(
+            `refined-bitbucket(sidebar-counters): ${resources.error.message}`
+        );
+        return '?';
+    }
+
+    return resources.size;
+};
+
+export const getPrCount = repoUrl =>
+    getResourcesCount(`${baseApiUrl}/${repoUrl}/pullrequests`);
+
+export const getBranchesCount = repoUrl =>
+    getResourcesCount(`${baseApiUrl}/${repoUrl}/refs/branches`);
+
+export const addBadge = (a, resourcesCount) => {
+    const div = a.parentNode;
+    div.style = 'position: relative;';
+
+    const badge = (
+        <span class="__rbb-badge">
+            <span class="__rbb-badge-counter">{resourcesCount}</span>
+        </span>
+    );
+    a.insertBefore(badge, a.firstChild);
+    return badge;
+};
+
+export default async function addSideBarCounters() {
+    // Exit early if can't find any of the nav links
+    // that we are going to augment with badge counters
+    const navLinksSelector = 'a[href$="branches/"], a[href$="pull-requests/"]';
+    const navLinks = document.querySelector(navLinksSelector);
+    if (!navLinks) {
+        return;
+    }
+
+    // Keep going
+    const repoUrl = getRepoURL();
+    const branchesCount = await getBranchesCount(repoUrl);
+    const pullrequestsCount = await getPrCount(repoUrl);
+
+    const navigation = document.getElementById('adg3-navigation');
+
+    let branchesBadge = { remove: () => {} };
+    let prBadge = { remove: () => {} };
+    navigation.observeSelector(navLinksSelector, function() {
+        if (this.href.endsWith('branches/')) {
+            branchesBadge.remove();
+            branchesBadge = addBadge(this, branchesCount);
+        } else if (this.href.endsWith('pull-requests/')) {
+            prBadge.remove();
+            prBadge = addBadge(this, pullrequestsCount);
+        }
+    });
+}

--- a/src/sidebar-counters/sidebar-counters.spec.js
+++ b/src/sidebar-counters/sidebar-counters.spec.js
@@ -1,0 +1,148 @@
+import { URL } from 'url';
+import test from 'ava';
+import { h } from 'dom-chef';
+import '../../test/setup-jsdom';
+
+import 'selector-observer';
+
+import { getResourcesCount, addBadge } from './sidebar-counters';
+import addSidebarCounters from '.';
+
+global.location = new URL('https://www.bitbucket.org/user/repo');
+
+global.fetch = {};
+
+const addMeta = () => {
+    const meta = (
+        <meta
+            name="apitoken"
+            content={'{"token": "...", "expiration": 1517595777.580439}'}
+        />
+    );
+    document.head.appendChild(meta);
+};
+
+test('getResourcesCount should return ? with error response', async t => {
+    addMeta();
+    global.fetch = () => {
+        return Promise.resolve({
+            json: () =>
+                Promise.resolve({ error: { message: 'some error happened' } })
+        });
+    };
+    const value = await getResourcesCount();
+    t.is(value, '?');
+});
+
+test('getResourcesCount should return correct size with successful response', async t => {
+    addMeta();
+    const size = 10;
+    global.fetch = () => {
+        return Promise.resolve({
+            json: () => Promise.resolve({ size })
+        });
+    };
+    const value = await getResourcesCount();
+    t.is(value, size);
+});
+
+test('addBadge should work properly', t => {
+    // Arrange
+    const actual = (
+        <div>
+            <a aria-disabled="false" href="/user/repo/branches/" class="jRoiuT">
+                <span class="bGyZgY" />
+            </a>
+        </div>
+    );
+
+    const resourcesCount = 5;
+    const expected = (
+        <div style={{ position: 'relative' }}>
+            <a aria-disabled="false" href="/user/repo/branches/" class="jRoiuT">
+                <span class="__rbb-badge">
+                    <span class="__rbb-badge-counter">{resourcesCount}</span>
+                </span>
+                <span class="bGyZgY" />
+            </a>
+        </div>
+    );
+
+    // Act
+    const a = actual.firstChild;
+    const badge = addBadge(a, resourcesCount);
+
+    // Assert
+    t.is(actual.outerHTML, expected.outerHTML);
+    t.true(badge instanceof HTMLSpanElement);
+});
+
+test('addSidebarCounters should exit early', async t => {
+    await addSidebarCounters();
+    t.pass();
+});
+
+test('addSidebarCounters should work properly', async t => {
+    // Arrange
+    addMeta();
+    const nav = (
+        <div id="adg3-navigation">
+            <div>
+                <a
+                    aria-disabled="false"
+                    href="/user/repo/branches/"
+                    class="jRoiuT"
+                />
+            </div>
+            <div>
+                <a
+                    aria-disabled="false"
+                    href="/user/repo/pull-requests/"
+                    class="jRoiuT"
+                />
+            </div>
+        </div>
+    );
+    document.body.appendChild(nav);
+
+    const size = 10;
+    const expected = (
+        <div id="adg3-navigation">
+            <div style={{ position: 'relative' }}>
+                <a
+                    aria-disabled="false"
+                    href="/user/repo/branches/"
+                    class="jRoiuT"
+                >
+                    <span class="__rbb-badge">
+                        <span class="__rbb-badge-counter">{size}</span>
+                    </span>
+                </a>
+            </div>
+            <div style={{ position: 'relative' }}>
+                <a
+                    aria-disabled="false"
+                    href="/user/repo/pull-requests/"
+                    class="jRoiuT"
+                >
+                    <span class="__rbb-badge">
+                        <span class="__rbb-badge-counter">{size}</span>
+                    </span>
+                </a>
+            </div>
+        </div>
+    );
+
+    global.fetch = () => {
+        return Promise.resolve({
+            json: () => Promise.resolve({ size })
+        });
+    };
+
+    // Act
+    await addSidebarCounters();
+
+    // Assert
+    t.is(nav.outerHTML, expected.outerHTML);
+    t.pass();
+});

--- a/test/setup-jsdom.js
+++ b/test/setup-jsdom.js
@@ -1,16 +1,27 @@
 'use strict';
 
+import { URL, URLSearchParams } from 'url';
 import jsdom from 'jsdom';
 
 const dom = new jsdom.JSDOM();
 global.window = dom.window;
 global.document = dom.window.document;
+global.navigator = dom.window.navigator;
+global.NodeList = dom.window.NodeList;
 global.Element = dom.window.Element;
 global.Text = dom.window.Text;
-global.HTMLTextAreaElement = dom.window.HTMLTextAreaElement;
 global.HTMLDivElement = dom.window.HTMLDivElement;
+global.HTMLTextAreaElement = dom.window.HTMLTextAreaElement;
+global.HTMLSpanElement = dom.window.HTMLSpanElement;
+
 global.requestAnimationFrame = fn => setTimeout(fn, 16);
 global.cancelAnimationFrame = id => clearTimeout(id);
+
+global.URL = URL;
+global.URLSearchParams = URLSearchParams;
+global.location = new URL('https://www.bitbucket.org');
+
+global.Headers = function() {};
 
 global.$ = global.jQuery = require('jquery');
 


### PR DESCRIPTION
Adds counters of the open or active "Branches" and "Pull requests"
to the links in the sidebar navigation menu.

Closes issue #133 

-----
Before:

![image](https://user-images.githubusercontent.com/7514993/35759150-35316238-084e-11e8-9a04-0e407ac5c1d2.png)

After:

<table>
<tr>
<td>
<img src="https://user-images.githubusercontent.com/7514993/35759127-0f886b44-084e-11e8-9e3a-58e9ce3da71a.png" alt="expanded"/> <br />
Expanded
</td>
<td><img src="https://user-images.githubusercontent.com/7514993/35742830-1c604af8-0812-11e8-936b-f6083599fb45.png" alt="collapsed" /> <br />
Collapsed</td>
</tr>
</table>