### PR TITLE
refactor: pull request list features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,27 @@
 ### Features:
 
 * **Sidebar Counters**: Adds counters of the open or active "Branches" and "Pull requests"
-  links in the sidebar navigation menu, closes [issue #133](https://github.com/refined-bitbucket/refined-bitbucket/issues/133),
+  links in the sidebar navigation menu,
+  closes [issue #133](https://github.com/refined-bitbucket/refined-bitbucket/issues/133),
   [pull request #134](https://github.com/refined-bitbucket/refined-bitbucket/pull/134).
-* **Source Branch**: Adds the source branch name next to the pull request title in the pull request list view and linkifies it along with the target branch, closes [issue #135](https://github.com/refined-bitbucket/refined-bitbucket/issues/135),
+* **Source Branch**: Adds the source branch name next to the pull request title in the
+  pull request list view and linkifies it along with the target branch,
+  closes [issue #135](https://github.com/refined-bitbucket/refined-bitbucket/issues/135),
   [pull request #136](https://github.com/refined-bitbucket/refined-bitbucket/pull/136).
+
+### Bug fixes:
+
+* **Ignore Whitespace**: Only the PRs that were initially loaded with the page were touched,
+  while any PR added dynamically to the DOM were not affected,
+  closes [issue #138](https://github.com/refined-bitbucket/refined-bitbucket/issues/138),
+  [pull request #139](https://github.com/refined-bitbucket/refined-bitbucket/pull/139).
 
 # 3.5.0 (2018-02-01)
 
 ### Features:
 
-* Improve the default font-family and size of lines of code in Source view, closes [issue #35](https://github.com/refined-bitbucket/refined-bitbucket/issues/35), [pull request #126](https://github.com/refined-bitbucket/refined-bitbucket/pull/126).
+* Improve the default font-family and size of lines of code in Source view,
+  closes [issue #35](https://github.com/refined-bitbucket/refined-bitbucket/issues/35), [pull request #126](https://github.com/refined-bitbucket/refined-bitbucket/pull/126).
 
 ### Language support:
 

--- a/src/ignore-whitespace/ignore-whitespace.js
+++ b/src/ignore-whitespace/ignore-whitespace.js
@@ -1,15 +1,8 @@
-import { isPullRequestList } from '../page-detect';
-
-export default function init() {
-    if (isPullRequestList()) {
-        const links = document.querySelectorAll('a.pull-request-title');
-
-        links.forEach(link => {
-            const url = new URL(link.href);
-            const searchParams = new URLSearchParams(url.search);
-            searchParams.set('w', 1);
-            url.search = searchParams.toString();
-            link.href = url.href;
-        });
-    }
+export default function init(prRow) {
+    const link = prRow.querySelector('a.pull-request-title');
+    const url = new URL(link.href);
+    const searchParams = new URLSearchParams(url.search);
+    searchParams.set('w', 1);
+    url.search = searchParams.toString();
+    link.href = url.href;
 }

--- a/src/ignore-whitespace/ignore-whitespace.spec.js
+++ b/src/ignore-whitespace/ignore-whitespace.spec.js
@@ -7,91 +7,60 @@ import '../../test/setup-jsdom';
 
 test('should transform pull request link to add ignore whitespace query param to 1', t => {
     const actual = (
-        <a
-            class="pull-request-title"
-            title="pull request title"
-            href="https://bitbucket.org/user/repo/pull-requests/1"
-        >
-            pull request title
-        </a>
+        <div>
+            <a
+                class="pull-request-title"
+                title="pull request title"
+                href="https://bitbucket.org/user/repo/pull-requests/1"
+            >
+                pull request title
+            </a>
+        </div>
     );
 
     const expected = (
-        <a
-            class="pull-request-title"
-            title="pull request title"
-            href="https://bitbucket.org/user/repo/pull-requests/1?w=1"
-        >
-            pull request title
-        </a>
+        <div>
+            <a
+                class="pull-request-title"
+                title="pull request title"
+                href="https://bitbucket.org/user/repo/pull-requests/1?w=1"
+            >
+                pull request title
+            </a>
+        </div>
     );
 
-    document.body.appendChild(actual);
-
-    location.href = 'https://www.bitbucket.org/user/repo/pull-requests/';
-
-    ignoreWhitespace();
+    ignoreWhitespace(actual);
 
     t.is(actual.outerHTML, expected.outerHTML);
 });
 
 test('should transform pull request link to toggle ignore whitespace query param to 1', t => {
     const actual = (
-        <a
-            class="pull-request-title"
-            title="pull request title"
-            href="https://bitbucket.org/user/repo/pull-requests/1?w=0"
-        >
-            pull request title
-        </a>
+        <div>
+            <a
+                class="pull-request-title"
+                title="pull request title"
+                href="https://bitbucket.org/user/repo/pull-requests/1?w=0"
+            >
+                pull request title
+            </a>
+        </div>
     );
 
     const expected = (
-        <a
-            class="pull-request-title"
-            title="pull request title"
-            href="https://bitbucket.org/user/repo/pull-requests/1?w=1"
-        >
-            pull request title
-        </a>
+        <div>
+            <a
+                class="pull-request-title"
+                title="pull request title"
+                href="https://bitbucket.org/user/repo/pull-requests/1?w=1"
+            >
+                pull request title
+            </a>
+        </div>
     );
 
-    document.body.appendChild(actual);
-
-    location.href = 'https://www.bitbucket.org/user/repo/pull-requests/';
-
-    ignoreWhitespace();
-
-    t.is(actual.outerHTML, expected.outerHTML);
-});
-
-test('should not transform pull request link if current page is not pull requests list', t => {
-    const actual = (
-        <a
-            class="pull-request-title"
-            title="pull request title"
-            href="https://bitbucket.org/user/repo/pull-requests/1"
-        >
-            pull request title
-        </a>
-    );
-
-    const expected = (
-        <a
-            class="pull-request-title"
-            title="pull request title"
-            href="https://bitbucket.org/user/repo/pull-requests/1"
-        >
-            pull request title
-        </a>
-    );
-
-    document.body.appendChild(actual);
-
-    location.href =
-        'https://www.bitbucket.org/user/repo/pull-requests/is-not-pull-request-page-list';
-
-    ignoreWhitespace();
+    ignoreWhitespace(actual);
 
     t.is(actual.outerHTML, expected.outerHTML);
 });

--- a/src/linkify-target-branch/index.js
+++ b/src/linkify-target-branch/index.js
@@ -1,0 +1,1 @@
+export { default } from './linkify-target-branch';

--- a/src/linkify-target-branch/linkify-target-branch.js
+++ b/src/linkify-target-branch/linkify-target-branch.js
@@ -1,0 +1,25 @@
+import { h } from 'dom-chef';
+
+import { getRepoURL } from '../page-detect';
+
+const repoUrl = getRepoURL();
+
+const linkifyTargetBranch = node => {
+    const targetBranchSpan = node.querySelector(
+        '.pull-request-target-branch span.name'
+    );
+    const targetBranchName = targetBranchSpan.textContent;
+    targetBranchSpan.removeChild(targetBranchSpan.lastChild);
+    const a = (
+        <a
+            style={{ color: '#707070' }}
+            title={targetBranchName}
+            href={`https://bitbucket.org/${repoUrl}/branch/${targetBranchName}`}
+        >
+            {targetBranchName}
+        </a>
+    );
+    targetBranchSpan.appendChild(a);
+};
+
+export default linkifyTargetBranch;

--- a/src/linkify-target-branch/linkify-target-branch.spec.js
+++ b/src/linkify-target-branch/linkify-target-branch.spec.js
@@ -1,0 +1,46 @@
+import { h } from 'dom-chef';
+import test from 'ava';
+
+import '../../test/setup-jsdom';
+
+import linkifyTargetBranch from '.';
+
+test('linkifyTargetBranch should work', t => {
+    const actual = (
+        <div class="title-and-target-branch">
+            <span class="pull-request-target-branch">
+                <span class="ref-label">
+                    <span class="ref branch">
+                        <span class="name" aria-label="branch develop">
+                            develop
+                        </span>
+                    </span>
+                </span>
+            </span>
+        </div>
+    );
+
+    const expected = (
+        <div class="title-and-target-branch">
+            <span class="pull-request-target-branch">
+                <span class="ref-label">
+                    <span class="ref branch">
+                        <span class="name" aria-label="branch develop">
+                            <a
+                                style={{ color: '#707070' }}
+                                title="develop"
+                                href="https://bitbucket.org//branch/develop"
+                            >
+                                develop
+                            </a>
+                        </span>
+                    </span>
+                </span>
+            </span>
+        </div>
+    );
+
+    linkifyTargetBranch(actual);
+
+    t.is(actual.outerHTML, expected.outerHTML);
+});

--- a/src/main.js
+++ b/src/main.js
@@ -10,12 +10,13 @@ import defaultMergeStrategy from './default-merge-strategy';
 import diffIgnore from './diff-ignore';
 import ignoreWhitespace from './ignore-whitespace';
 import keymap from './keymap';
+import linkifyTargetBranch from './linkify-target-branch';
 import loadAllDiffs from './load-all-diffs';
 import occurrencesHighlighter from './occurrences-highlighter';
 import insertPullrequestTemplate from './pullrequest-template';
-import syntaxHighlight from './syntax-highlight';
 import addSidebarCounters from './sidebar-counters';
-import addSourceBranchToPrList from './source-branch';
+import addSourceBranch from './source-branch';
+import syntaxHighlight from './syntax-highlight';
 
 import waitForPullRequestContents from './wait-for-pullrequest';
 import {
@@ -44,13 +45,7 @@ function init(config) {
         codeReviewFeatures(config, getPullrequestNodePromise);
         pullrequestRelatedFeatures(config);
     } else if (isPullRequestList()) {
-        if (config.ignoreWhitespace) {
-            ignoreWhitespace();
-        }
-
-        if (config.addSourceBranchToPrList) {
-            addSourceBranchToPrList();
-        }
+        pullrequestListRelatedFeatures(config);
     } else if (isCreatePullRequestURL() || isEditPullRequestURL()) {
         if (isCreatePullRequestURL() && config.prTemplateEnabled) {
             insertPullrequestTemplate(config.prTemplateUrl);
@@ -73,6 +68,26 @@ function init(config) {
     if (config.addSidebarCounters) {
         addSidebarCounters();
     }
+}
+
+function pullrequestListRelatedFeatures(config) {
+    // Exit early if none of the pr list related features are enabled
+    if (!config.ignoreWhitespace && !config.addSourceBranchToPrList) {
+        return;
+    }
+
+    const prTable = document.querySelector('.pull-requests-table');
+
+    prTable.observeSelector('tr.pull-request-row', function() {
+        if (config.ignoreWhitespace) {
+            ignoreWhitespace(this);
+        }
+
+        if (config.addSourceBranchToPrList) {
+            linkifyTargetBranch(this);
+            addSourceBranch(this);
+        }
+    });
 }
 
 function codeReviewFeatures(config, getNodePromise) {

--- a/src/source-branch/source-branch.js
+++ b/src/source-branch/source-branch.js
@@ -49,25 +49,8 @@ const buildSourceBranchNode = branchName => {
     );
 };
 
-export const linkifyTargetBranchNode = node => {
-    const targetBranchSpan = node.querySelector('span.name');
-    const targetBranchName = targetBranchSpan.textContent;
-    targetBranchSpan.removeChild(targetBranchSpan.lastChild);
-    const a = (
-        <a
-            style={{ color: '#707070' }}
-            title={targetBranchName}
-            href={`https://bitbucket.org/${repoUrl}/branch/${targetBranchName}`}
-        >
-            {targetBranchName}
-        </a>
-    );
-    targetBranchSpan.appendChild(a);
-};
-
-export const addSourceBranchNode = async prNode => {
-    const row = prNode.closest('tr');
-    const prId = row.dataset.pullRequestId;
+export default async function addSourceBranch(prNode) {
+    const prId = prNode.dataset.pullRequestId;
     const sourceBranchName = await getPrSourceBranch(prId);
 
     if (!sourceBranchName) {
@@ -78,14 +61,5 @@ export const addSourceBranchNode = async prNode => {
     const arrow = prNode.querySelector(
         'span.aui-iconfont-devtools-arrow-right'
     );
-    prNode.insertBefore(sourceBranchNode, arrow);
-};
-
-export default function addSourceBranchToPrList() {
-    const prTable = document.querySelector('.pull-requests-table');
-
-    prTable.observeSelector('.title-and-target-branch', function() {
-        linkifyTargetBranchNode(this);
-        addSourceBranchNode(this);
-    });
+    arrow.parentElement.insertBefore(sourceBranchNode, arrow);
 }

--- a/src/source-branch/source-branch.spec.js
+++ b/src/source-branch/source-branch.spec.js
@@ -1,18 +1,10 @@
 import { h } from 'dom-chef';
 import test from 'ava';
-import delay from 'yoctodelay';
 
-import { addApiTokenMetadata, cleanDocumentBody } from '../../test/test-utils';
+import { addApiTokenMetadata } from '../../test/test-utils';
 import '../../test/setup-jsdom';
 
-import {
-    getPrSourceBranch,
-    linkifyTargetBranchNode,
-    addSourceBranchNode
-} from './source-branch';
-import addSourceBranchToPrList from '.';
-
-import 'selector-observer';
+import addSourceBranch, { getPrSourceBranch } from './source-branch';
 
 const mockFetchWithErrorResponse = () => {
     global.fetch = () => {
@@ -37,70 +29,9 @@ const mockFetchWithSuccessfulResponse = branchName => {
     };
 };
 
-test('getPrSourceBranch should return undefined on error', async t => {
-    addApiTokenMetadata();
-
-    mockFetchWithErrorResponse();
-
-    const sourceBranch = await getPrSourceBranch();
-
-    t.is(sourceBranch, undefined);
-});
-
-test('getPrSourceBranch should return branch name on success', async t => {
-    addApiTokenMetadata();
-
-    const expectedBranchName = 'source-branch-name';
-    mockFetchWithSuccessfulResponse(expectedBranchName);
-
-    const sourceBranch = await getPrSourceBranch();
-
-    t.is(sourceBranch, expectedBranchName);
-});
-
-test('linkifyTargetBranchNode should work', t => {
-    const actual = (
-        <div class="title-and-target-branch">
-            <span class="pull-request-target-branch">
-                <span class="ref-label">
-                    <span class="ref branch">
-                        <span class="name" aria-label="branch develop">
-                            develop
-                        </span>
-                    </span>
-                </span>
-            </span>
-        </div>
-    );
-
-    const expected = (
-        <div class="title-and-target-branch">
-            <span class="pull-request-target-branch">
-                <span class="ref-label">
-                    <span class="ref branch">
-                        <span class="name" aria-label="branch develop">
-                            <a
-                                style={{ color: '#707070' }}
-                                title="develop"
-                                href="https://bitbucket.org//branch/develop"
-                            >
-                                develop
-                            </a>
-                        </span>
-                    </span>
-                </span>
-            </span>
-        </div>
-    );
-
-    linkifyTargetBranchNode(actual);
-
-    t.is(actual.outerHTML, expected.outerHTML);
-});
-
-test('addSourceBranchNode should work', async t => {
-    const actual = (
-        <table>
+const buildPrTable = () => {
+    return (
+        <table class="aui paged-table pull-requests-table">
             <tr class="pull-request-row focused" data-pull-request-id="1">
                 <div class="title-and-target-branch">
                     <a
@@ -124,10 +55,49 @@ test('addSourceBranchNode should work', async t => {
             </tr>
         </table>
     );
+};
+
+test('getPrSourceBranch should return undefined on error', async t => {
+    addApiTokenMetadata();
+
+    mockFetchWithErrorResponse();
+
+    const sourceBranch = await getPrSourceBranch();
+
+    t.is(sourceBranch, undefined);
+});
+
+test('getPrSourceBranch should return branch name on success', async t => {
+    addApiTokenMetadata();
+
+    const expectedBranchName = 'source-branch-name';
+    mockFetchWithSuccessfulResponse(expectedBranchName);
+
+    const sourceBranch = await getPrSourceBranch();
+
+    t.is(sourceBranch, expectedBranchName);
+});
+
+test('addSourceBranch should not add source branch node on API error', async t => {
+    const actual = buildPrTable();
+
+    const expected = actual.cloneNode(true);
+
+    mockFetchWithErrorResponse();
+    addApiTokenMetadata();
+
+    const prNode = actual.querySelector('.pull-request-row');
+    await addSourceBranch(prNode);
+
+    t.is(actual.outerHTML, expected.outerHTML);
+});
+
+test('addSourceBranch should insert source branch node on success', async t => {
+    const actual = buildPrTable();
 
     const sourceBranch = 'source-branch';
     const expected = (
-        <table>
+        <table class="aui paged-table pull-requests-table">
             <tr class="pull-request-row focused" data-pull-request-id="1">
                 <div class="title-and-target-branch">
                     <a
@@ -177,158 +147,8 @@ test('addSourceBranchNode should work', async t => {
     mockFetchWithSuccessfulResponse(sourceBranch);
     addApiTokenMetadata();
 
-    await addSourceBranchNode(actual.querySelector('.title-and-target-branch'));
+    const prNode = actual.querySelector('.pull-request-row');
+    await addSourceBranch(prNode);
 
     t.is(actual.outerHTML, expected.outerHTML);
 });
-
-const buildPrTable = () => {
-    return (
-        <table class="aui paged-table pull-requests-table">
-            <tr class="pull-request-row focused" data-pull-request-id="1">
-                <div class="title-and-target-branch">
-                    <a
-                        class="pull-request-title"
-                        title="Pull request title"
-                        href="https://bitbucket.org/user/repo/pull-requests/1"
-                    >
-                        Pull request title
-                    </a>
-                    <span class="aui-icon aui-icon-small aui-iconfont-devtools-arrow-right" />
-                    <span class="pull-request-target-branch">
-                        <span class="ref-label">
-                            <span class="ref branch">
-                                <span class="name" aria-label="branch develop">
-                                    develop
-                                </span>
-                            </span>
-                        </span>
-                    </span>
-                </div>
-            </tr>
-        </table>
-    );
-};
-
-test('addSourceBranchToPrList should not add source branch node on API error', async t => {
-    const prTable = buildPrTable();
-    document.body.appendChild(prTable);
-    const expected = (
-        <table class="aui paged-table pull-requests-table">
-            <tr class="pull-request-row focused" data-pull-request-id="1">
-                <div class="title-and-target-branch">
-                    <a
-                        class="pull-request-title"
-                        title="Pull request title"
-                        href="https://bitbucket.org/user/repo/pull-requests/1"
-                    >
-                        Pull request title
-                    </a>
-
-                    <span class="aui-icon aui-icon-small aui-iconfont-devtools-arrow-right" />
-
-                    <span class="pull-request-target-branch">
-                        <span class="ref-label">
-                            <span class="ref branch">
-                                <span class="name" aria-label="branch develop">
-                                    <a
-                                        style={{ color: '#707070' }}
-                                        title="develop"
-                                        href="https://bitbucket.org//branch/develop"
-                                    >
-                                        develop
-                                    </a>
-                                </span>
-                            </span>
-                        </span>
-                    </span>
-                </div>
-            </tr>
-        </table>
-    );
-
-    mockFetchWithErrorResponse();
-
-    addApiTokenMetadata();
-    addSourceBranchToPrList();
-
-    await delay(32);
-
-    t.is(prTable.outerHTML, expected.outerHTML);
-    cleanDocumentBody();
-});
-
-test.serial(
-    'addSourceBranchToPrList should insert source branch node on success',
-    async t => {
-        const prTable = buildPrTable();
-        document.body.appendChild(prTable);
-
-        const sourceBranch = 'source-branch-name';
-        const expected = (
-            <table class="aui paged-table pull-requests-table">
-                <tr class="pull-request-row focused" data-pull-request-id="1">
-                    <div class="title-and-target-branch">
-                        <a
-                            class="pull-request-title"
-                            title="Pull request title"
-                            href="https://bitbucket.org/user/repo/pull-requests/1"
-                        >
-                            Pull request title
-                        </a>
-
-                        {/* Added this */}
-                        <span class="__rbb-pull-request-source-branch">
-                            <span class="ref-label">
-                                <span class="ref branch">
-                                    <span
-                                        class="name"
-                                        aria-label={`branch ${sourceBranch}`}
-                                    >
-                                        <a
-                                            style={{ color: '#707070' }}
-                                            title={sourceBranch}
-                                            href={`https://bitbucket.org//branch/${sourceBranch}`}
-                                        >
-                                            {sourceBranch}
-                                        </a>
-                                    </span>
-                                </span>
-                            </span>
-                        </span>
-
-                        <span class="aui-icon aui-icon-small aui-iconfont-devtools-arrow-right" />
-
-                        <span class="pull-request-target-branch">
-                            <span class="ref-label">
-                                <span class="ref branch">
-                                    <span
-                                        class="name"
-                                        aria-label="branch develop"
-                                    >
-                                        <a
-                                            style={{ color: '#707070' }}
-                                            title="develop"
-                                            href="https://bitbucket.org//branch/develop"
-                                        >
-                                            develop
-                                        </a>
-                                    </span>
-                                </span>
-                            </span>
-                        </span>
-                    </div>
-                </tr>
-            </table>
-        );
-
-        mockFetchWithSuccessfulResponse(sourceBranch);
-        addApiTokenMetadata();
-        addSourceBranchToPrList();
-
-        await delay(32);
-
-        t.is(prTable.outerHTML, expected.outerHTML);
-        cleanDocumentBody();
-    }
-);


### PR DESCRIPTION
Refactor all the code related to the PR list view features to split the 
functionality related to linkifying target branch namesand adding the 
PR's source branch name.

Also, the ignore whitespace by default feature was involved in the 
refactor and a bug was solved as a consequence, where only the PRs that 
were initially loaded with the page were touched, while any PR added 
dynamically to the DOM were not affected.

Related to issue #135 and pr #136.

Closes issue #138.

* [x] ~I updated the README.md, with pictures if necessary~ (N/A)
* [x] I added Automated Tests
* [x] I updated the CHANGELOG.md
* [x] ~I added an Option to enable / disable this feature~  (N/A)
* [x] I tested the changes in this pull request myself

