### PR TITLE
Expanded Perl file extension support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
   closes [issue #135](https://github.com/refined-bitbucket/refined-bitbucket/issues/135),
   [pull request #136](https://github.com/refined-bitbucket/refined-bitbucket/pull/136).
 
+### Language support:
+
+* **Perl**: Expanded Perl support to include Perl module and test file extensions (\*.t/\*.pm).
+
 ### Bug fixes:
 
 * **Ignore Whitespace**: Only the PRs that were initially loaded with the page were touched,

--- a/src/syntax-highlight/language-ext.js
+++ b/src/syntax-highlight/language-ext.js
@@ -43,6 +43,8 @@ module.exports = {
     '.m': 'language-objectivec',
     '.md': 'language-markdown',
     '.pl': 'language-perl',
+    '.pm': 'language-perl',
+    '.t': 'language-perl',
     '.py': 'language-python',
     '.php': 'language-php',
     '.phtml': 'language-php',


### PR DESCRIPTION
.t and .pm file extensions are both used by Perl for test files and modules respectively, this extends the syntax highlighter to recognise them as Perl.

* [X] I updated the CHANGELOG.md 
