### PR TITLE
fix: syntax highlighting not working in v3.4 - v3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@
   the collapse/toggle diff top button was misplaced,
   closes [issue #122](https://github.com/refined-bitbucket/refined-bitbucket/issues/122),
   [pull request #140](https://github.com/refined-bitbucket/refined-bitbucket/pull/140).
+* **Syntax Highlighting**: Syntax highlighting was not working for anyone who installed the
+  extension for the first time on version 3.4.0 or 3.5.0, due to the refactoring made
+  to the Options mechanism in [pull request #107](https://github.com/refined-bitbucket/refined-bitbucket/pull/107),
+  closes [issue #143](https://github.com/refined-bitbucket/refined-bitbucket/issues/143),
+  [pull request #146](https://github.com/refined-bitbucket/refined-bitbucket/pull/146).
 
 ### Language support:
 

--- a/src/background.js
+++ b/src/background.js
@@ -18,7 +18,7 @@ chrome.runtime.onInstalled.addListener(details => {
 chrome.storage.sync.get(null, deprecatedOptions => {
     new OptionsSync().define({
         defaults: {
-            highlightSyntax: true,
+            syntaxHighlight: true,
             highlightOcurrences: true,
             ignoreWhitespace: true,
             keymap: true,

--- a/src/main.js
+++ b/src/main.js
@@ -116,7 +116,7 @@ function codeReviewFeatures(config, getNodePromise) {
                 }
                 autocollapse.collapseIfNeeded(this);
 
-                if (config.highlightSyntax && !diffIgnore.isIgnored(this)) {
+                if (config.syntaxHighlight && !diffIgnore.isIgnored(this)) {
                     syntaxHighlight(this);
                 }
             });


### PR DESCRIPTION
Syntax highlighting was not working for anyone who installed
the extension for the first time on version 3.4.0 or 3.5.0, due to
the refactoring made to the Options mechanism in pull request #107.

Close issue #143

Co-Authored-By: Danielle Cerisier @dpekkle 

* [x] I updated the CHANGELOG.md
* [x] I tested the changes in this pull request myself
