### PR TITLE
feat: Don't include diff's pluses and minuses in clipboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Next Release
 
-### Improvements:
+### Features:
 
 * Bring old link color (blue) back to pull request and repository titles,
   [pull request #153](https://github.com/refined-bitbucket/refined-bitbucket/pull/153).
+* Don't carry pluses and minuses to clipboard when copying diff's contents,
+  closes [issue #149](https://github.com/refined-bitbucket/refined-bitbucket/issues/149),
+  [pull request #156](https://github.com/refined-bitbucket/refined-bitbucket/pull/156).
 
 ### Language support:
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ We all know BitBucket lacks some features that we have in other platforms like G
 * Choose a default merge strategy for your pull requests.
 * Check the "Close anchor branch" checkbox by default when creating or editing pull requests.
 * Adds the source branch name next to the pull request title in the pull request list view and linkifies it along with the target branch.
+* Don't carry pluses and minuses to clipboard when copying diff's contents.
 * Include a `PULL_REQUEST_TEMPLATE.md` file in the default branch of the repository in one of the locations below, and the contents of that file template will replace the default pull request body inserted by Bitbucket when creating a new one.
 
     ```

--- a/src/background.js
+++ b/src/background.js
@@ -29,6 +29,7 @@ chrome.storage.sync.get(null, deprecatedOptions => {
             oldLinkColor: true,
             addSidebarCounters: true,
             addSourceBranchToPrList: true,
+            diffPlusesAndMinuses: true,
             prTemplateEnabled: true,
             defaultMergeStrategy: 'merge_commit',
             autocollapsePaths: ['package-lock.json', 'yarn.lock'],

--- a/src/diff-pluses-and-minuses/diff-pluses-and-minuses.css
+++ b/src/diff-pluses-and-minuses/diff-pluses-and-minuses.css
@@ -1,0 +1,9 @@
+.addition > .source:before {
+    content: '+';
+    color: #a67f59;
+}
+
+.deletion > .source:before {
+    content: '-';
+    color: #a67f59;
+}

--- a/src/diff-pluses-and-minuses/diff-pluses-and-minuses.js
+++ b/src/diff-pluses-and-minuses/diff-pluses-and-minuses.js
@@ -1,0 +1,84 @@
+let stylesImported = false;
+
+export const execute = diff => {
+    [
+        ...diff.querySelectorAll(
+            'div.udiff-line > pre.source, div.udiff-line > pre.source > span.token:first-of-type'
+        )
+    ]
+        .filter(({ firstChild }) => {
+            return (
+                firstChild instanceof Text &&
+                /^\+|-/.test(firstChild.textContent)
+            );
+        })
+        .forEach(({ firstChild }) => {
+            // Insert only a space to preserve
+            // line breaks when the line is empty
+            if (
+                firstChild.textContent === '+' ||
+                firstChild.textContent === '-'
+            ) {
+                firstChild.textContent = ' ';
+            } else {
+                firstChild.textContent = firstChild.textContent.slice(1);
+            }
+        });
+};
+
+/**
+ * Keep watching in case the diff is altered to include
+ * word diffs, which rerenders the diffs with <ins> and <del> tags
+ * and ends up removing any previous manipulation we did with it :(
+ *
+ * @param {HTMLElement} diff
+ */
+export const observeForWordDiffs = diff => {
+    return new Promise(resolve => {
+        const diffContentContainer = diff.querySelector(
+            'div.diff-container > div.diff-content-container.refract-container'
+        );
+
+        // Return earlier if couldn't find the element,
+        // which happens when the diff failed to load
+        if (!diffContentContainer) {
+            resolve();
+            return;
+        }
+
+        const observer = new MutationObserver(function(mutations) {
+            const isWordDiff = mutations.every(m =>
+                m.target.classList.contains('word-diff')
+            );
+
+            if (isWordDiff) {
+                this.disconnect();
+                execute(diff);
+                resolve();
+            }
+        });
+
+        observer.observe(diffContentContainer, {
+            attributes: true,
+            attributeFilter: ['class']
+        });
+
+        // Disconnect the observer after an arbitrary 20 seconds,
+        // to release browser resources.
+        setTimeout(() => {
+            observer.disconnect();
+            resolve();
+        }, 20000);
+    });
+};
+
+export default function removeDiffsPlusesAndMinuses(diff) {
+    if (!stylesImported) {
+        stylesImported = true;
+        require('./diff-pluses-and-minuses.css');
+    }
+
+    execute(diff);
+
+    observeForWordDiffs(diff);
+}

--- a/src/diff-pluses-and-minuses/diff-pluses-and-minuses.spec.js
+++ b/src/diff-pluses-and-minuses/diff-pluses-and-minuses.spec.js
@@ -1,0 +1,246 @@
+import test from 'ava';
+import { h } from 'dom-chef';
+
+import { execute, observeForWordDiffs } from './diff-pluses-and-minuses';
+
+import '../../test/setup-jsdom';
+
+test('should remove pluses and minues for regular diff', t => {
+    const uudiff = (
+        <section class="bb-udiff" data-filename="filename.js">
+            <div class="refract-content-container">
+                <div class="udiff-line addition">
+                    <div class="gutter">
+                        <a
+                            href="#add-comment"
+                            class="add-diff-comment add-line-comment"
+                            title="Add a comment to this line"
+                        >
+                            <span class="aui-icon aui-icon-small aui-iconfont-add-comment">
+                                Add a comment to this line
+                            </span>
+                        </a>
+                        <a class="line-numbers" data-fnum="1" data-tnum="1" />
+                    </div>
+                    <pre class="source">+var msg = 'Hello world';</pre>
+                </div>
+            </div>
+        </section>
+    );
+
+    const expected = (
+        <section class="bb-udiff" data-filename="filename.js">
+            <div class="refract-content-container">
+                <div class="udiff-line addition">
+                    <div class="gutter">
+                        <a
+                            href="#add-comment"
+                            class="add-diff-comment add-line-comment"
+                            title="Add a comment to this line"
+                        >
+                            <span class="aui-icon aui-icon-small aui-iconfont-add-comment">
+                                Add a comment to this line
+                            </span>
+                        </a>
+                        <a class="line-numbers" data-fnum="1" data-tnum="1" />
+                    </div>
+                    <pre class="source">var msg = 'Hello world';</pre>
+                </div>
+            </div>
+        </section>
+    );
+
+    execute(uudiff);
+
+    t.is(uudiff.outerHTML, expected.outerHTML);
+});
+
+test('should remove pluses and minues for syntax highlighted diff', t => {
+    const uudiff = (
+        <section class="bb-udiff" data-filename="filename.js">
+            <div class="refract-content-container">
+                <div class="udiff-line addition">
+                    <div class="gutter">
+                        <a
+                            href="#add-comment"
+                            class="add-diff-comment add-line-comment"
+                            title="Add a comment to this line"
+                        >
+                            <span class="aui-icon aui-icon-small aui-iconfont-add-comment">
+                                Add a comment to this line
+                            </span>
+                        </a>
+                        <a class="line-numbers" data-fnum="1" data-tnum="1" />
+                    </div>
+
+                    <pre class="source language-jsx">
+                        <span class="token operator">+</span>
+                        <span class="token keyword">var</span> msg
+                        <span class="token operator">=</span>
+                        <span class="token string">'Hello world'</span>
+                        <span class="token punctuation">;</span>
+                    </pre>
+                </div>
+            </div>
+        </section>
+    );
+
+    const expected = (
+        <section class="bb-udiff" data-filename="filename.js">
+            <div class="refract-content-container">
+                <div class="udiff-line addition">
+                    <div class="gutter">
+                        <a
+                            href="#add-comment"
+                            class="add-diff-comment add-line-comment"
+                            title="Add a comment to this line"
+                        >
+                            <span class="aui-icon aui-icon-small aui-iconfont-add-comment">
+                                Add a comment to this line
+                            </span>
+                        </a>
+                        <a class="line-numbers" data-fnum="1" data-tnum="1" />
+                    </div>
+
+                    <pre class="source language-jsx">
+                        <span class="token operator"> </span>
+                        <span class="token keyword">var</span> msg
+                        <span class="token operator">=</span>
+                        <span class="token string">'Hello world'</span>
+                        <span class="token punctuation">;</span>
+                    </pre>
+                </div>
+            </div>
+        </section>
+    );
+
+    execute(uudiff);
+
+    t.is(uudiff.outerHTML, expected.outerHTML);
+});
+
+test('line breaks are preserved with empty whitespace', t => {
+    const uudiff = (
+        <section class="bb-udiff" data-filename="filename.js">
+            <div class="refract-content-container">
+                <div class="udiff-line addition">
+                    <div class="gutter">
+                        <a
+                            href="#add-comment"
+                            class="add-diff-comment add-line-comment"
+                            title="Add a comment to this line"
+                        >
+                            <span class="aui-icon aui-icon-small aui-iconfont-add-comment">
+                                Add a comment to this line
+                            </span>
+                        </a>
+                        <a class="line-numbers" data-fnum="1" data-tnum="1" />
+                    </div>
+                    <pre class="source">+var msg = 'Hello world';</pre>
+                    <pre class="source">+</pre>
+                    <pre class="source">+var greeting = 'How are you?';</pre>
+                </div>
+            </div>
+        </section>
+    );
+
+    const expected = (
+        <section class="bb-udiff" data-filename="filename.js">
+            <div class="refract-content-container">
+                <div class="udiff-line addition">
+                    <div class="gutter">
+                        <a
+                            href="#add-comment"
+                            class="add-diff-comment add-line-comment"
+                            title="Add a comment to this line"
+                        >
+                            <span class="aui-icon aui-icon-small aui-iconfont-add-comment">
+                                Add a comment to this line
+                            </span>
+                        </a>
+                        <a class="line-numbers" data-fnum="1" data-tnum="1" />
+                    </div>
+                    <pre class="source">var msg = 'Hello world';</pre>
+                    <pre class="source"> </pre>
+                    <pre class="source">var greeting = 'How are you?';</pre>
+                </div>
+            </div>
+        </section>
+    );
+
+    execute(uudiff);
+
+    t.is(uudiff.outerHTML, expected.outerHTML);
+});
+
+test('should remove pluses and minuses when diff has been rerendered to include word diffs', async t => {
+    const uudiff = (
+        <section class="bb-udiff" data-filename="filename.js">
+            <div class="diff-container">
+                <div class="diff-content-container refract-container">
+                    <div class="refract-content-container">
+                        <div class="udiff-line addition">
+                            <pre class="source">+var msg = 'Hello world';</pre>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+    );
+
+    const observingPromise = observeForWordDiffs(uudiff);
+
+    const diffContentContainer = uudiff.querySelector(
+        'div.diff-container > div.diff-content-container.refract-container'
+    );
+    diffContentContainer.classList.add('word-diff');
+
+    const expected = (
+        <section class="bb-udiff" data-filename="filename.js">
+            <div class="diff-container">
+                <div class="diff-content-container refract-container word-diff">
+                    <div class="refract-content-container">
+                        <div class="udiff-line addition">
+                            <pre class="source">var msg = 'Hello world';</pre>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+    );
+
+    await observingPromise;
+
+    t.is(uudiff.outerHTML, expected.outerHTML);
+});
+
+test('should do nothing and not throw or error when diff fails to load', async t => {
+    const uudiff = (
+        <section class="bb-udiff" data-filename="filename.js">
+            <div class="diff-message-container">
+                <div class="aui-message info too-big-message">
+                    <p class="title">
+                        <span class="aui-icon icon-info" />
+                        <strong class="try-again">
+                            Oops! You've got a lot of code in this diff and it
+                            couldn't load with the page.
+                        </strong>
+                        <a href="#" class="load-diff try-again">
+                            Click here to give it another chance.
+                        </a>
+                        <strong class="try-again-failed">
+                            Now that is a lot of code! There's simply too much
+                            in this diff for us to render it all.
+                        </strong>
+                    </p>
+                </div>
+            </div>
+        </section>
+    );
+
+    const expected = uudiff.cloneNode(true);
+
+    await observeForWordDiffs(uudiff);
+
+    t.is(uudiff.outerHTML, expected.outerHTML);
+});

--- a/src/diff-pluses-and-minuses/index.js
+++ b/src/diff-pluses-and-minuses/index.js
@@ -1,0 +1,1 @@
+export { default } from './diff-pluses-and-minuses';

--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,7 @@ import closeAnchorBranch from './close-anchor-branch';
 import collapseDiff from './collapse-diff';
 import defaultMergeStrategy from './default-merge-strategy';
 import diffIgnore from './diff-ignore';
+import removeDiffsPlusesAndMinuses from './diff-pluses-and-minuses';
 import ignoreWhitespace from './ignore-whitespace';
 import keymap from './keymap';
 import linkifyTargetBranch from './linkify-target-branch';
@@ -115,12 +116,20 @@ function codeReviewFeatures(config, getNodePromise) {
             // have to observe the DOM because some sections
             // load asynchronously by user demand
             node.observeSelector('section.bb-udiff', function() {
+                if (diffIgnore.isIgnored(this)) {
+                    return;
+                }
+
                 if (config.collapseDiff) {
                     collapseDiff.insertCollapseDiffButton(this);
                 }
                 autocollapse.collapseIfNeeded(this);
 
-                if (config.syntaxHighlight && !diffIgnore.isIgnored(this)) {
+                if (config.diffPlusesAndMinuses) {
+                    removeDiffsPlusesAndMinuses(this);
+                }
+
+                if (config.syntaxHighlight) {
                     syntaxHighlight(this);
                 }
             });

--- a/src/options.html
+++ b/src/options.html
@@ -75,6 +75,12 @@
         <br>
 
         <label>
+            <input type="checkbox" name="diffPlusesAndMinuses"> Don't carry pluses and minuses to clipboard when copying diff's contents
+        </label>
+        <br>
+        <br>
+
+        <label>
             <input type="checkbox" name="prTemplateEnabled"> Use a
             <em>PULL_REQUEST_TEMPLATE.md</em> from the repository when creating new pull requests or specify a URL with your
             own raw template (must be hosted publicly in

--- a/src/syntax-highlight/syntax-highlight.spec.js
+++ b/src/syntax-highlight/syntax-highlight.spec.js
@@ -3,10 +3,6 @@ import test from 'ava';
 
 import '../../test/setup-jsdom';
 
-require('mutationobserver-shim');
-
-global.MutationObserver = window.MutationObserver;
-
 require('../vendor/prism.js');
 
 const syntaxHighlight = require('.').default;

--- a/test/setup-jsdom.js
+++ b/test/setup-jsdom.js
@@ -49,3 +49,7 @@ window.Element.prototype.closest =
 // `scrollIntoView` not supported by jsdom,
 // shim with a no-op
 window.Element.prototype.scrollIntoView = () => {};
+
+require('mutationobserver-shim');
+
+global.MutationObserver = window.MutationObserver;


### PR DESCRIPTION
Don't carry pluses and minuses to clipboard when copying diff's contents.

Closes #149

---

**Before**:

![remove-plus-and-minus-from-diff-before](https://user-images.githubusercontent.com/7514993/36508452-1f27d064-1733-11e8-9d90-76b815612642.gif)

**After**

![remove-plus-and-minus-from-diff-2](https://user-images.githubusercontent.com/7514993/36133714-68da1f98-1056-11e8-9c3a-2c7e790ce69d.gif)

---

<!--
    Check those that apply, and delete the ones that don't
-->

* [x] I updated the README.md, with pictures if necessary
* [x] I added Automated Tests
* [x] I updated the CHANGELOG.md
* [x] I added an Option to enable / disable this feature
* [x] I tested the changes in this pull request myself
