### PR TITLE
fix(close-anchor-branch): should only apply when creating PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@
   closes [issue #149](https://github.com/refined-bitbucket/refined-bitbucket/issues/149),
   [pull request #156](https://github.com/refined-bitbucket/refined-bitbucket/pull/156).
 
+### Bug fixes:
+
+* The "Close anchor branch" checkbox was being checked even
+  in the PR editing screen. It's been fixed now so that it only works
+  in the creation screen, like how it should've been all along,
+  closes [issue #155](https://github.com/refined-bitbucket/refined-bitbucket/issues/155),
+  [pull request #157](https://github.com/refined-bitbucket/refined-bitbucket/pull/157).
+
 ### Language support:
 
 * **Perl**: Expanded Perl support to include Perl test files and template toolkit (\*.t, \*.tt).

--- a/src/main.js
+++ b/src/main.js
@@ -23,7 +23,6 @@ import waitForPullRequestContents from './wait-for-pullrequest';
 import {
     isPullRequest,
     isCreatePullRequestURL,
-    isEditPullRequestURL,
     isPullRequestList,
     isCommit
 } from './page-detect';
@@ -47,8 +46,8 @@ function init(config) {
         pullrequestRelatedFeatures(config);
     } else if (isPullRequestList()) {
         pullrequestListRelatedFeatures(config);
-    } else if (isCreatePullRequestURL() || isEditPullRequestURL()) {
-        if (isCreatePullRequestURL() && config.prTemplateEnabled) {
+    } else if (isCreatePullRequestURL()) {
+        if (config.prTemplateEnabled) {
             insertPullrequestTemplate(config.prTemplateUrl);
         }
 


### PR DESCRIPTION
The "Close anchor branch" checkbox was being checked even
in the PR editing screen. It's been fixed now so that it only works
in the creation screen, like how it should've been all along.

Closes #155

* [ ] ~I updated the README.md, with pictures if necessary~
* [ ] ~I added Automated Tests~
* [x] I updated the CHANGELOG.md
* [ ] ~I added an Option to enable / disable this feature~
* [x] I tested the changes in this pull request myself
