### PR TITLE
fix: don't remove unintended characters from line diffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,19 @@
 # Next Version
 
-### Improvements:
+### Features:
 
 * Code review features now available in branch compare view,
   closes [issue #128](https://github.com/refined-bitbucket/refined-bitbucket/issues/128),
   [pull request #159](https://github.com/refined-bitbucket/refined-bitbucket/pull/159).
+
+### Bug fixes:
+
+* The "Don't carry pluses and minuses to clipboard" feature is supposed
+  to delete "+" and "-" characters from line diffs, but it was mistakenly
+  removing some other characters,
+  closes [issue #160](https://github.com/refined-bitbucket/refined-bitbucket/issues/160),
+  closes [issue #161](https://github.com/refined-bitbucket/refined-bitbucket/issues/161),
+  [pull request #162](https://github.com/refined-bitbucket/refined-bitbucket/pull/162).
 
 # 3.7.0 (2018-02-26)
 

--- a/src/augment-pr-entry/augment-pr-entry.spec.js
+++ b/src/augment-pr-entry/augment-pr-entry.spec.js
@@ -39,6 +39,8 @@ const mockFetchWithSuccessfulResponse = ({
     };
 };
 
+Date.now = () => new Date('02/22/2018').getTime();
+
 const buildPrTable = () => {
     return (
         <table class="aui paged-table pull-requests-table">

--- a/src/diff-pluses-and-minuses/diff-pluses-and-minuses.js
+++ b/src/diff-pluses-and-minuses/diff-pluses-and-minuses.js
@@ -3,15 +3,12 @@ let stylesImported = false;
 export const execute = diff => {
     [
         ...diff.querySelectorAll(
-            'div.udiff-line > pre.source, div.udiff-line > pre.source > span.token:first-of-type'
+            'div.udiff-line.addition > pre.source, div.udiff-line.deletion > pre.source, ' +
+                'div.udiff-line.addition > pre.source > span.token:first-of-type, ' +
+                'div.udiff-line.deletion > pre.source > span.token:first-of-type'
         )
     ]
-        .filter(({ firstChild }) => {
-            return (
-                firstChild instanceof Text &&
-                /^\+|-/.test(firstChild.textContent)
-            );
-        })
+        .filter(({ firstChild }) => firstChild instanceof Text)
         .forEach(({ firstChild }) => {
             // Insert only a space to preserve
             // line breaks when the line is empty

--- a/src/diff-pluses-and-minuses/diff-pluses-and-minuses.spec.js
+++ b/src/diff-pluses-and-minuses/diff-pluses-and-minuses.spec.js
@@ -27,6 +27,14 @@ test('should remove pluses and minues for regular diff', t => {
                     </div>
                     <pre class="source">+var msg = 'Hello world';</pre>
                 </div>
+                <div class="udiff-line common">
+                    <pre class="source">white-space: nowrap;</pre>
+                </div>
+                <div class="udiff-line addition">
+                    <pre class="source">
+                        + + Constants.page_rma, this.bleReadData, false);
+                    </pre>
+                </div>
             </div>
         </section>
     );
@@ -48,6 +56,15 @@ test('should remove pluses and minues for regular diff', t => {
                         <a class="line-numbers" data-fnum="1" data-tnum="1" />
                     </div>
                     <pre class="source">var msg = 'Hello world';</pre>
+                </div>
+                <div class="udiff-line common">
+                    <pre class="source">white-space: nowrap;</pre>
+                </div>
+                <div class="udiff-line addition">
+                    <pre class="source">
+                        {' '}
+                        + Constants.page_rma, this.bleReadData, false);
+                    </pre>
                 </div>
             </div>
         </section>

--- a/src/syntax-highlight/syntax-highlight.js
+++ b/src/syntax-highlight/syntax-highlight.js
@@ -12,7 +12,7 @@ import './fix.css';
 
 const codeContainerObserver = new MutationObserver(mutations => {
     mutations.forEach(mutation =>
-        syntaxHighlightSourceCodeLines(mutation.target)
+        syntaxHighlightSourceCodeLines($(mutation.target))
     );
 });
 
@@ -67,6 +67,10 @@ export default function syntaxHighlight(diff, afterWordDiff) {
 }
 
 function syntaxHighlightSourceCodeLines($diff) {
+    if (!$diff.find) {
+        console.log($diff);
+    }
+
     const sourceLines = Array.from(
         $diff.find('pre:not([class*=language]), pre:has(ins), pre:has(del)')
     );


### PR DESCRIPTION
The "Don't carry pluses and minuses to clipboard" feature is supposed
to delete "+" and "-" characters from line diffs, but it was mistakenly
removing some other characters.

Closes #160
Closes #161

---

* [x] I added Automated Tests
* [x] I updated the CHANGELOG.md
* [x] I tested the changes in this pull request myself
