### PR TITLE
ft: badge with number of commits in pull request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Next Version
+
+### Features:
+
+* Insert badge with the number of commits of the current pull request next to the "Commits" tab,
+  closes [issue #163](https://github.com/refined-bitbucket/refined-bitbucket/issues/163),
+  [pull request #164](https://github.com/refined-bitbucket/refined-bitbucket/pull/164).
+
 # 3.7.3 (2018-03-08)
 
 From now on, you have the option to disable update notifications that open a new browser tab each time a new version

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ We all know BitBucket lacks some features that we have in other platforms like G
 * Check the "Close anchor branch" checkbox by default when creating or editing pull requests.
 * Add source branch, linkify branch names, and add creation date to each pull request row in pull request list.
 * Don't carry pluses and minuses to clipboard when copying diff's contents.
+* Badge with the number of commits of the current pull request next to the "Commits" tab.
 * Include a `PULL_REQUEST_TEMPLATE.md` file in the default branch of the repository in one of the locations below, and the contents of that file template will replace the default pull request body inserted by Bitbucket when creating a new one.
 
     ```

--- a/src/augment-pr-entry/augment-pr-entry.js
+++ b/src/augment-pr-entry/augment-pr-entry.js
@@ -3,7 +3,6 @@ import { ago } from 'time-ago';
 
 import getApiToken from '../get-api-token';
 import logger from '../logger';
-
 import { getRepoURL } from '../page-detect';
 
 import './augment-pr-entry.css';
@@ -12,7 +11,6 @@ import linkifyTargetBranch from '../linkify-target-branch/linkify-target-branch'
 const repoUrl = getRepoURL();
 
 export const getPrData = async prId => {
-    const repoUrl = getRepoURL();
     const url = `https://api.bitbucket.org/2.0/repositories/${repoUrl}/pullrequests/${prId}`;
     const token = getApiToken();
     const response = await fetch(url, {

--- a/src/background.js
+++ b/src/background.js
@@ -26,6 +26,7 @@ new OptionsSync().define({
         diffPlusesAndMinuses: true,
         augmentPrEntry: true,
         prTemplateEnabled: true,
+        pullrequestCommitAmount: true,
         defaultMergeStrategy: 'merge_commit',
         autocollapsePaths: ['package-lock.json', 'yarn.lock'].join('\n'),
         autocollapseDeletedFiles: true,

--- a/src/main.js
+++ b/src/main.js
@@ -15,6 +15,7 @@ import keymap from './keymap';
 import linkifyTargetBranch from './linkify-target-branch';
 import loadAllDiffs from './load-all-diffs';
 import occurrencesHighlighter from './occurrences-highlighter';
+import pullrequestCommitAmount from './pullrequest-commit-amount';
 import insertPullrequestTemplate from './pullrequest-template';
 import addSidebarCounters from './sidebar-counters';
 import syntaxHighlight from './syntax-highlight';
@@ -165,5 +166,9 @@ function pullrequestRelatedFeatures(config) {
 
     if (config.keymap) {
         keymap.init();
+    }
+
+    if (config.pullrequestCommitAmount) {
+        pullrequestCommitAmount();
     }
 }

--- a/src/options.html
+++ b/src/options.html
@@ -76,6 +76,12 @@
         <br>
 
         <label>
+            <input type="checkbox" name="pullrequestCommitAmount"> Include number of commits next to the Commits tab in the pull request view
+        </label>
+        <br>
+        <br>
+
+        <label>
             <input type="checkbox" name="prTemplateEnabled"> Use a
             <em>PULL_REQUEST_TEMPLATE.md</em> from the repository when creating new pull requests or specify a URL with your
             own raw template (must be hosted publicly in

--- a/src/pullrequest-commit-amount/index.js
+++ b/src/pullrequest-commit-amount/index.js
@@ -1,0 +1,1 @@
+export { default } from './pullrequest-commit-amount';

--- a/src/pullrequest-commit-amount/pullrequest-commit-amount.css
+++ b/src/pullrequest-commit-amount/pullrequest-commit-amount.css
@@ -1,0 +1,8 @@
+.__rbb-commit-ammount {
+    display: inline-block;
+    padding: 2px 5px;
+    font-size: 10px;
+    line-height: 1;
+    background-color: rgba(27, 31, 35, 0.08);
+    border-radius: 20px;
+}

--- a/src/pullrequest-commit-amount/pullrequest-commit-amount.js
+++ b/src/pullrequest-commit-amount/pullrequest-commit-amount.js
@@ -1,0 +1,48 @@
+import { h } from 'dom-chef';
+import elementReady from 'element-ready';
+
+import { getRepoURL } from '../page-detect';
+import getApiToken from '../get-api-token';
+import logger from '../logger';
+
+import './pullrequest-commit-amount.css';
+
+const getCommitsAmount = async prId => {
+    const repoUrl = getRepoURL();
+    const url = `https://api.bitbucket.org/2.0/repositories/${repoUrl}/pullrequests/${prId}/commits`;
+    const token = getApiToken();
+    const response = await fetch(url, {
+        headers: new Headers({
+            Authorization: `Bearer ${token}`
+        })
+    });
+    const commitsData = await response.json();
+
+    if (commitsData.error) {
+        logger.error(
+            `refined-bitbucket(pullrequest-commit-amount): ${
+                commitsData.error.message
+            }`
+        );
+        return;
+    }
+
+    return commitsData.size;
+};
+
+export default async function pullrequestCommitAmount() {
+    const prNode = await elementReady('#pullrequest');
+    const prId = prNode.dataset.localId;
+
+    const commitsAmount = await getCommitsAmount(prId);
+
+    if (!commitsAmount) {
+        return prNode;
+    }
+
+    const badge = <span class="__rbb-commit-ammount">{commitsAmount}</span>;
+    const commitsLink = document.getElementById('pr-menu-commits');
+    commitsLink.appendChild(badge);
+
+    return prNode;
+}

--- a/src/pullrequest-commit-amount/pullrequest-commit-amount.spec.js
+++ b/src/pullrequest-commit-amount/pullrequest-commit-amount.spec.js
@@ -1,0 +1,69 @@
+import test from 'ava';
+import { h } from 'dom-chef';
+import '../../test/setup-jsdom';
+import { addApiTokenMetadata } from '../../test/test-utils';
+
+import pullrequestCommitAmount from '.';
+
+// Consider using `nock` package in the future
+const mockFetchWithErrorResponse = () => {
+    global.fetch = () => {
+        return Promise.resolve({
+            json: () => Promise.resolve({ error: true })
+        });
+    };
+};
+
+const mockFetchWithSuccessfulResponse = () => {
+    global.fetch = () => {
+        return Promise.resolve({
+            json: () =>
+                Promise.resolve({
+                    size: 1
+                })
+        });
+    };
+};
+
+test('should insert commit amount badge', async t => {
+    addApiTokenMetadata();
+    mockFetchWithSuccessfulResponse();
+
+    const node = (
+        <section id="pullrequest" data-local-id="1">
+            <a id="pr-menu-commits">Commits</a>
+        </section>
+    );
+    document.body.appendChild(node);
+
+    const expected = (
+        <section id="pullrequest" data-local-id="1">
+            <a id="pr-menu-commits">
+                Commits
+                <span class="__rbb-commit-ammount">1</span>
+            </a>
+        </section>
+    );
+
+    const actual = await pullrequestCommitAmount();
+
+    t.is(actual.outerHTML, expected.outerHTML);
+});
+
+test.serial('should NOT insert commit amount badge on API error', async t => {
+    addApiTokenMetadata();
+    mockFetchWithErrorResponse();
+
+    const node = (
+        <section id="pullrequest" data-local-id="1">
+            <a id="pr-menu-commits">Commits</a>
+        </section>
+    );
+    document.body.appendChild(node);
+
+    const expected = node.cloneNode(true);
+
+    const actual = await pullrequestCommitAmount();
+
+    t.is(actual.outerHTML, expected.outerHTML);
+});

--- a/src/syntax-highlight/syntax-highlight.js
+++ b/src/syntax-highlight/syntax-highlight.js
@@ -67,10 +67,6 @@ export default function syntaxHighlight(diff, afterWordDiff) {
 }
 
 function syntaxHighlightSourceCodeLines($diff) {
-    if (!$diff.find) {
-        console.log($diff);
-    }
-
     const sourceLines = Array.from(
         $diff.find('pre:not([class*=language]), pre:has(ins), pre:has(del)')
     );


### PR DESCRIPTION
Insert badge with the number of commits of the current pull request next to the "Commits" tab.

NOTE: The code base of the features and tests is getting a little convoluted and with a lot of code
duplication. This could be vastly improved with a refactor, but I just haven't had time. Once I've finished
with the backlog of features and fixes that I have on my mind right now, I'll get on it.

**Before**

![before](https://user-images.githubusercontent.com/7514993/36793748-922ca0f8-1c74-11e8-85fc-76fd2e6cd788.png)

**After**

![after](https://user-images.githubusercontent.com/7514993/36794180-02f07ebc-1c76-11e8-8ce4-45f8bbbbf325.png)

Closes #163

* [x] I updated the README.md, with pictures if necessary
* [x] I added Automated Tests
* [x] I updated the CHANGELOG.md
* [x] I added an Option to enable / disable this feature
* [x] I tested the changes in this pull request myself
