### PR TITLE
fix: don't remove unintended chars from diff (p2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# Next Version
+
+### Bug fixes:
+
+* The "Don't carry pluses and minuses to clipboard" feature is supposed
+  to delete "+" and "-" characters from line diffs, but it was mistakenly
+  removing some other characters.
+  The previous attempt in pull request #162 at solving issue #161 didn't actually solve it,
+  closes [issue #161](https://github.com/refined-bitbucket/refined-bitbucket/issues/161),
+  [pull request #165](https://github.com/refined-bitbucket/refined-bitbucket/pull/165).
+
 # 3.7.1 (2018-02-28)
 
 ### Features:

--- a/src/diff-pluses-and-minuses/diff-pluses-and-minuses.js
+++ b/src/diff-pluses-and-minuses/diff-pluses-and-minuses.js
@@ -1,15 +1,20 @@
 let stylesImported = false;
 
-export const execute = diff => {
-    [
-        ...diff.querySelectorAll(
-            'div.udiff-line.addition > pre.source, div.udiff-line.deletion > pre.source, ' +
-                'div.udiff-line.addition > pre.source > span.token:first-of-type, ' +
-                'div.udiff-line.deletion > pre.source > span.token:first-of-type'
-        )
-    ]
+const selectors = [
+    'div.udiff-line.addition > pre.source:not([class*=__rbb-touched])',
+    'div.udiff-line.deletion > pre.source:not([class*=__rbb-touched])',
+    'div.udiff-line.addition > pre.source:has(ins,del)',
+    'div.udiff-line.deletion > pre.source:has(ins,del)'
+];
+
+export const execute = $diff => {
+    const diffLines = [...$diff.find(selectors.join(', '))];
+
+    diffLines
         .filter(({ firstChild }) => firstChild instanceof Text)
-        .forEach(({ firstChild }) => {
+        .forEach(el => {
+            el.classList.add('__rbb-touched');
+            const { firstChild } = el;
             // Insert only a space to preserve
             // line breaks when the line is empty
             if (
@@ -29,7 +34,9 @@ export default function removeDiffsPlusesAndMinuses(diff, afterWordDiff) {
         require('./diff-pluses-and-minuses.css');
     }
 
-    execute(diff);
+    const $diff = $(diff);
 
-    afterWordDiff(() => execute(diff));
+    execute($diff);
+
+    afterWordDiff(() => execute($diff));
 }


### PR DESCRIPTION
The "Don't carry pluses and minuses to clipboard" feature is supposed
to delete "+" and "-" characters from line diffs, but it was mistakenly
removing some other characters.

Previous attempt in pull request #162 solved issue #160 but not #161.

Closes #161

* [x] I added Automated Tests
* [x] I updated the CHANGELOG.md
* [x] I tested the changes in this pull request myself