### PR TITLE
add powershell syntax highlighting

### DIFF
--- a/src/syntax-highlight/language-ext.js
+++ b/src/syntax-highlight/language-ext.js
@@ -43,6 +43,7 @@ module.exports = {
     '.phtml': 'language-php',
     '.pl': 'language-perl',
     '.pm': 'language-perl',
+    '.ps1': 'language-powershell',
     '.py': 'language-python',
     '.rb': 'language-ruby',
     '.rlib': 'language-rust',


### PR DESCRIPTION
<!--
    Check those that apply, and delete the ones that don't
-->
![powershell-syntax-highlighter](https://user-images.githubusercontent.com/1205434/36937214-f5f5034e-1edd-11e8-8e0e-2d27a9533a49.PNG)

* [x] I tested the changes in this pull request myself

---
