### PR TITLE
add syntax highlight support for Jenkinsfile & Vagrantfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Language support:
 
+* **Vagrantfile & Jenkinsfile**: Support for Jenkinsfile & Vagrantfile syntax highlighting.
+  [pull request #174](https://github.com/refined-bitbucket/refined-bitbucket/pull/174).
 * Powershell language support for (\*.ps1) files,
   [pull request #173](https://github.com/refined-bitbucket/refined-bitbucket/pull/173).
 

--- a/src/syntax-highlight/language-ext.js
+++ b/src/syntax-highlight/language-ext.js
@@ -1,3 +1,5 @@
+/* eslint quote-props: off */
+
 // These are only the file extensions that don't directly match
 // the class name to be used by PrismJS to highlight the code,
 // or the ones to be overriden.
@@ -63,5 +65,9 @@ module.exports = {
     '.wxs': 'language-markup',
     '.xaml': 'language-markup',
     '.xsd': 'language-markup',
-    '.yml': 'language-yaml'
+    '.yml': 'language-yaml',
+
+    // Universally named files
+    jenkinsfile: 'language-groovy',
+    vagrantfile: 'language-ruby'
 };

--- a/src/syntax-highlight/source-handler.js
+++ b/src/syntax-highlight/source-handler.js
@@ -12,12 +12,17 @@ import languagesExtensions from './language-ext';
  * @param  {Element} element An HTML element. Pass anything different and bear the consequences :)
  * @return {String} The class extracted from the element's file path.
  */
-export function getClassBasedOnExtension(element) {
+export function getLanguageClass(element) {
     const filePath = getFilepathFromElement(element);
     const fileExtension = getExtension(filePath).toLowerCase();
 
     if (fileExtension in languagesExtensions) {
         return languagesExtensions[fileExtension];
+    }
+
+    const fileName = getFilename(filePath).toLowerCase();
+    if (fileName in languagesExtensions) {
+        return languagesExtensions[fileName];
     }
 
     const fileExtensionWithoutDot = fileExtension.slice(1);
@@ -49,4 +54,13 @@ export function getFilepathFromElement(element) {
  */
 export function getExtension(filepath) {
     return `.${filepath.slice(((filepath.lastIndexOf('.') - 1) >>> 0) + 2)}`;
+}
+
+/**
+ * Extracts the name of the current file to be highlighted
+ * @param {String} filepath
+ * @return {String} name of the file
+ */
+function getFilename(filepath) {
+    return filepath.slice(filepath.lastIndexOf('/') + 1);
 }

--- a/src/syntax-highlight/source-handler.spec.js
+++ b/src/syntax-highlight/source-handler.spec.js
@@ -8,10 +8,30 @@ import '../../test/setup-jsdom';
 
 test('Adds a language-xxxx class to the element that has a data-filename attr', t => {
     const element = <div data-filename="z/path/to/file/the-file.java" />;
-    const languageClass = sourceHandler.getClassBasedOnExtension(element);
+    const languageClass = sourceHandler.getLanguageClass(element);
     t.is(
         languageClass,
         'language-java',
         'proper language-xxxx class added to the element'
+    );
+});
+
+test('Adds a language-ruby class to the element that has a data-filename attr for a Vagrantfile', t => {
+    const element = <div data-filename="z/path/to/Vagrantfile" />;
+    const languageClass = sourceHandler.getLanguageClass(element);
+    t.is(
+        languageClass,
+        'language-ruby',
+        'proper language-ruby class added to the element'
+    );
+});
+
+test('Adds a language-ruby class to the element that has a data-filename attr for a Jenknsfile', t => {
+    const element = <div data-filename="z/path/to/Jenkinsfile" />;
+    const languageClass = sourceHandler.getLanguageClass(element);
+    t.is(
+        languageClass,
+        'language-groovy',
+        'proper language-groovy class added to the element'
     );
 });

--- a/src/syntax-highlight/syntax-highlight.js
+++ b/src/syntax-highlight/syntax-highlight.js
@@ -5,7 +5,7 @@
 import { h } from 'dom-chef';
 import elementReady from 'element-ready';
 import debounce from '../debounce';
-import { getClassBasedOnExtension } from './source-handler';
+import { getLanguageClass } from './source-handler';
 
 import './prism.css';
 import './fix.css';
@@ -28,7 +28,7 @@ export default function syntaxHighlight(diff, afterWordDiff) {
         return;
     }
 
-    const languageClass = getClassBasedOnExtension(diff);
+    const languageClass = getLanguageClass(diff);
 
     if (!languageClass) {
         return;


### PR DESCRIPTION

![jenkinsfile-support](https://user-images.githubusercontent.com/1205434/36937072-d59fe476-1edb-11e8-8301-528e13a36916.PNG)
![vagrantfile-syntax-highlight](https://user-images.githubusercontent.com/1205434/36937073-d5af4b3c-1edb-11e8-9073-58ddebae8c83.PNG)


* [x] I tested the changes in this pull request myself

---
