### PR TITLE
fix(options): allow disable update notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Next Version
+
+### Improvements:
+
+* Now you can disable update notifications through the Options page,
+  closes [issue #167](https://github.com/refined-bitbucket/refined-bitbucket/issues/167),
+  [pull request #176](https://github.com/refined-bitbucket/refined-bitbucket/pull/176).
+
 # 3.7.2 (2018-02-28)
 
 ### Bug fixes:

--- a/src/background.js
+++ b/src/background.js
@@ -2,62 +2,45 @@
 
 import OptionsSync from 'webext-options-sync';
 
-chrome.runtime.onInstalled.addListener(details => {
-    if (details.reason === 'install' || details.reason === 'update') {
-        window.open(
-            'https://github.com/refined-bitbucket/refined-bitbucket/releases/latest'
-        );
-    }
+const justInstalledOrUpdated = new Promise((resolve, reject) => {
+    chrome.runtime.onInstalled.addListener(details => {
+        if (details.reason === 'install' || details.reason === 'update') {
+            resolve();
+        } else {
+            reject();
+        }
+    });
 });
 
-/**
- *  Needed to migrate any saved settings from v3.3.0
- *  and below to v3.4.0 and above
- */
-// null to get the entire storage
-chrome.storage.sync.get(null, deprecatedOptions => {
-    new OptionsSync().define({
-        defaults: {
-            syntaxHighlight: true,
-            highlightOcurrences: true,
-            ignoreWhitespace: true,
-            keymap: true,
-            collapseDiff: true,
-            loadAllDiffs: true,
-            closeAnchorBranch: true,
-            improveFonts: true,
-            addSidebarCounters: true,
-            diffPlusesAndMinuses: true,
-            augmentPrEntry: true,
-            prTemplateEnabled: true,
-            defaultMergeStrategy: 'merge_commit',
-            autocollapsePaths: ['package-lock.json', 'yarn.lock'],
-            autocollapseDeletedFiles: true,
-            ignorePaths: ['']
+new OptionsSync().define({
+    defaults: {
+        syntaxHighlight: true,
+        highlightOcurrences: true,
+        ignoreWhitespace: true,
+        keymap: true,
+        collapseDiff: true,
+        loadAllDiffs: true,
+        closeAnchorBranch: true,
+        improveFonts: true,
+        addSidebarCounters: true,
+        diffPlusesAndMinuses: true,
+        augmentPrEntry: true,
+        prTemplateEnabled: true,
+        defaultMergeStrategy: 'merge_commit',
+        autocollapsePaths: ['package-lock.json', 'yarn.lock'],
+        autocollapseDeletedFiles: true,
+        ignorePaths: [''],
+        eneableUpdateNotifications: true
+    },
+    migrations: [
+        async savedOptions => {
+            if (savedOptions.eneableUpdateNotifications) {
+                await justInstalledOrUpdated;
+                window.open(
+                    'https://github.com/refined-bitbucket/refined-bitbucket/releases/latest'
+                );
+            }
         },
-        migrations: [
-            (newOptions, currentDefaults) => {
-                Object.keys(currentDefaults).forEach(key => {
-                    if (key in deprecatedOptions) {
-                        newOptions[key] = deprecatedOptions[key];
-                    }
-                });
-
-                // Until v3.3.0, these paths were saved as arrays.
-                // Since we are now using 'webext-options-sync',
-                // every stored value must be a primitive
-                if (Array.isArray(newOptions.ignorePaths)) {
-                    newOptions.ignorePaths = newOptions.ignorePaths.join('\n');
-                }
-                if (Array.isArray(newOptions.autocollapsePaths)) {
-                    newOptions.autocollapsePaths = newOptions.autocollapsePaths.join(
-                        '\n'
-                    );
-                }
-
-                chrome.storage.sync.clear();
-            },
-            OptionsSync.migrations.removeUnused
-        ]
-    });
+        OptionsSync.migrations.removeUnused
+    ]
 });

--- a/src/options.html
+++ b/src/options.html
@@ -119,6 +119,16 @@
             </div>
             <textarea name="ignorePaths" rows="7" cols="60"></textarea>
         </div>
+
+        <br>
+        <hr>
+        <label style="display: flex; justify-content: space-between; align-items: center">
+            <span style="width: calc(100% - 30px)">
+                Enable Update Notifications. Every time this extension is updated, the CHANGELOG for the current version will be opened in
+                a new browser tab.
+            </span>
+            <input type="checkbox" name="eneableUpdateNotifications">
+        </label>
     </form>
 
     <script src="options.js"></script>


### PR DESCRIPTION
Now you can disable update notifications through the Options page.

Closes #167

* [x] I updated the CHANGELOG.md
* [x] I tested the changes in this pull request myself

![image](https://user-images.githubusercontent.com/7514993/37067539-b5e706b2-2180-11e8-8b7c-04f49ef19af5.png)
