### PR TITLE
fix(diff): extra leading pluses/minuses in diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,17 @@
 * Display author of the lastest activity on a pull request,
   closes [issue #154](https://github.com/refined-bitbucket/refined-bitbucket/issues/154),
   [pull request #187](https://github.com/refined-bitbucket/refined-bitbucket/pull/187).
-
 * Insert badge with the number of commits of the current pull request next to the "Commits" tab,
   closes [issue #163](https://github.com/refined-bitbucket/refined-bitbucket/issues/163),
   [pull request #164](https://github.com/refined-bitbucket/refined-bitbucket/pull/164).
+
+### Bug fixes:
+
+* Fixed extra leading minus/plus sign in diffs when "Don't carry pluses and minuses to clipboard"
+  feature is enabled,
+  closes [issue #168](https://github.com/refined-bitbucket/refined-bitbucket/issues/168),
+  closes [issue #175](https://github.com/refined-bitbucket/refined-bitbucket/issues/175),
+  [pull request #177](https://github.com/refined-bitbucket/refined-bitbucket/pull/177).
 
 ### Language support:
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -2,10 +2,10 @@
     Check those that apply, and delete the ones that don't
 -->
 
-* [ ] I updated the README.md, with pictures if necessary
-* [ ] I added Automated Tests
 * [ ] I updated the CHANGELOG.md
-* [ ] I added an Option to enable / disable this feature
 * [ ] I tested the changes in this pull request myself
+* [ ] I added Automated Tests
+* [ ] I added an Option to enable / disable this feature
+* [ ] I updated the README.md, with pictures if necessary
 
 ---

--- a/src/diff-pluses-and-minuses/diff-pluses-and-minuses.spec.js
+++ b/src/diff-pluses-and-minuses/diff-pluses-and-minuses.spec.js
@@ -3,9 +3,7 @@ import { h } from 'dom-chef';
 import delay from 'yoctodelay';
 
 import observeForWordDiffs from '../observe-for-word-diffs';
-import removeDiffsPlusesAndMinuses, {
-    execute
-} from './diff-pluses-and-minuses';
+import removeDiffsPlusesAndMinuses from './diff-pluses-and-minuses';
 
 import '../../test/setup-jsdom';
 
@@ -51,9 +49,7 @@ test('should remove pluses and minues for regular diff', t => {
                         </a>
                         <a class="line-numbers" data-fnum="1" data-tnum="1" />
                     </div>
-                    <pre class="source __rbb-touched">
-                        var msg = 'Hello world';
-                    </pre>
+                    <pre class="source">var msg = 'Hello world';</pre>
                 </div>
                 <div class="udiff-line common">
                     <pre class="source">white-space: nowrap;</pre>
@@ -62,7 +58,7 @@ test('should remove pluses and minues for regular diff', t => {
         </section>
     );
 
-    execute($(udiff));
+    removeDiffsPlusesAndMinuses(udiff);
 
     t.is(udiff.outerHTML, expected.outerHTML);
 });
@@ -108,25 +104,21 @@ test('line breaks are preserved with empty whitespace', t => {
                         </a>
                         <a class="line-numbers" data-fnum="1" data-tnum="1" />
                     </div>
-                    <pre class="source __rbb-touched">
-                        var msg = 'Hello world';
-                    </pre>
-                    <pre class="source __rbb-touched"> </pre>
-                    <pre class="source __rbb-touched">
-                        var greeting = 'How are you?';
-                    </pre>
+                    <pre class="source">var msg = 'Hello world';</pre>
+                    <pre class="source"> </pre>
+                    <pre class="source">var greeting = 'How are you?';</pre>
                 </div>
             </div>
         </section>
     );
 
-    execute($(udiff));
+    removeDiffsPlusesAndMinuses(udiff);
 
     t.is(udiff.outerHTML, expected.outerHTML);
 });
 
 test('should remove pluses and minuses when diff has been rerendered to include word diffs', async t => {
-    const uudiff = (
+    const udiff = (
         <section class="bb-udiff" data-filename="filename.js">
             <div class="diff-container">
                 <h1 class="filename">
@@ -142,6 +134,9 @@ test('should remove pluses and minuses when diff has been rerendered to include 
                         </div>
                         <div class="udiff-line addition" id="diffed">
                             <pre class="source">+console.log(msg);</pre>
+                        </div>
+                        <div class="udiff-line addition" id="diffed-2">
+                            <pre class="source">+return;</pre>
                         </div>
                     </div>
                 </div>
@@ -161,15 +156,16 @@ test('should remove pluses and minuses when diff has been rerendered to include 
                 <div class="diff-content-container refract-container word-diff">
                     <div class="refract-content-container">
                         <div class="udiff-line addition">
-                            <pre class="source __rbb-touched">
-                                var msg = 'Hello world';
-                            </pre>
+                            <pre class="source">var msg = 'Hello world';</pre>
                         </div>
 
                         <div class="udiff-line addition" id="diffed">
-                            <pre class="source __rbb-touched">
+                            <pre class="source">
                                 console.<ins>log(msg);</ins>
                             </pre>
+                        </div>
+                        <div class="udiff-line addition" id="diffed-2">
+                            <pre class="source">return;</pre>
                         </div>
                     </div>
                 </div>
@@ -178,18 +174,23 @@ test('should remove pluses and minuses when diff has been rerendered to include 
     );
 
     // Act
-    const afterWordDiff = observeForWordDiffs(uudiff);
-    removeDiffsPlusesAndMinuses(uudiff, afterWordDiff);
+    const afterWordDiff = observeForWordDiffs(udiff);
+    removeDiffsPlusesAndMinuses(udiff, afterWordDiff);
 
     // Adding word diff
-    const line = uudiff.querySelector('#diffed');
+    const line = udiff.querySelector('#diffed');
     const diffedLine = (
-        <pre class="source __rbb-touched">
+        <pre class="source">
             +console.<ins>log(msg);</ins>
         </pre>
     );
     line.replaceChild(diffedLine, line.firstChild);
-    const diffContentContainer = uudiff.querySelector(
+
+    const line2 = udiff.querySelector('#diffed-2');
+    const diffedLine2 = <pre class="source">+return;</pre>;
+    line2.replaceChild(diffedLine2, line2.firstChild);
+
+    const diffContentContainer = udiff.querySelector(
         'div.diff-container > div.diff-content-container.refract-container'
     );
     diffContentContainer.classList.add('word-diff');
@@ -197,7 +198,7 @@ test('should remove pluses and minuses when diff has been rerendered to include 
     await delay(32);
 
     // Assert
-    t.is(uudiff.outerHTML, expected.outerHTML);
+    t.is(udiff.outerHTML, expected.outerHTML);
 });
 
 test('should do nothing and not throw or error when diff fails to load', async t => {
@@ -226,7 +227,7 @@ test('should do nothing and not throw or error when diff fails to load', async t
 
     const expected = udiff.cloneNode(true);
 
-    execute($(udiff));
+    removeDiffsPlusesAndMinuses(udiff);
 
     t.is(udiff.outerHTML, expected.outerHTML);
 });

--- a/src/observe-for-word-diffs.js
+++ b/src/observe-for-word-diffs.js
@@ -20,7 +20,8 @@ const observeForWordDiffs = (diff, timeout = 20000) => {
 
         const isModifiedOrConflict = diff.querySelector(
             'h1.filename span.diff-entry-lozenge.aui-lozenge-complete, ' +
-                'h1.filename span.diff-entry-lozenge.aui-lozenge-current'
+                'h1.filename span.diff-entry-lozenge.aui-lozenge-current, ' +
+                'h1.filename span.diff-entry-lozenge.aui-lozenge-moved'
         );
 
         // Only "Modified" and "Conflict" diffs will include word diffs


### PR DESCRIPTION
Bitbucket re-renders diff lines into the DOM when including word diffs without actually adding any `<ins>` or `<del>` tags to their markup. Since the previous implementation was relying on the presence of those tags to determine which lines were re-rendered, lines that didn't have them were not being picked up by our function in the second pass, and those were the ones that remained with the extra "-" or "+".

Now the implementation has been changed so that we determine which lines were re-rendered by comparing the contents of those lines **before** the word diff has been applied, and after. This solution is not only better (possibly fail-proof), but also doesn't depend on jQuery, and the resulting code is smaller, cleaner and more succinct.

Closes #168
Closes #175 

* [x] I added Automated Tests
* [x] I updated the CHANGELOG.md
* [x] I tested the changes in this pull request myself