### PR TITLE
fix: "Add source branch" feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
   closes [issue #167](https://github.com/refined-bitbucket/refined-bitbucket/issues/167),
   [pull request #176](https://github.com/refined-bitbucket/refined-bitbucket/pull/176).
 
+### Bug fixes:
+
+* The "Add source branch" feature was not working unless the "Set Ignore whitespace ON" was enabled,
+  closes [issue #169](https://github.com/refined-bitbucket/refined-bitbucket/issues/169),
+  [pull request #179](https://github.com/refined-bitbucket/refined-bitbucket/pull/179).
+
 # 3.7.2 (2018-02-28)
 
 ### Bug fixes:

--- a/src/main.js
+++ b/src/main.js
@@ -72,7 +72,7 @@ function init(config) {
 
 function pullrequestListRelatedFeatures(config) {
     // Exit early if none of the pr list related features are enabled
-    if (!config.ignoreWhitespace && !config.addSourceBranchToPrList) {
+    if (!config.ignoreWhitespace && !config.augmentPrEntry) {
         return;
     }
 


### PR DESCRIPTION
The "Add source branch" feature was not working unless the "Set Ignore whitespace ON" was enabled.

Closes #169

* [x] I updated the CHANGELOG.md
* [x] I tested the changes in this pull request myself