### PR TITLE
fix: default options saved as arrays

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -27,9 +27,9 @@ new OptionsSync().define({
         augmentPrEntry: true,
         prTemplateEnabled: true,
         defaultMergeStrategy: 'merge_commit',
-        autocollapsePaths: ['package-lock.json', 'yarn.lock'],
+        autocollapsePaths: ['package-lock.json', 'yarn.lock'].join('\n'),
         autocollapseDeletedFiles: true,
-        ignorePaths: [''],
+        ignorePaths: [''].join('\n'),
         eneableUpdateNotifications: true
     },
     migrations: [


### PR DESCRIPTION
Options saved by default as arrays where appearing as comma separated values in textareas.

Save them as plain strings instead the way we want them to appear directly.

