### PR TITLE
Adds a link to create pull request from compare page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+### Features:
+
+* Adds a 'Create a Pull Request' link to the 'Compare branches of tags' page, closes [issue 189](https://github.com/refined-bitbucket/refined-bitbucket/issues/189), [pull request #191](https://github.com/refined-bitbucket/refined-bitbucket/pull/191)
+
 # 3.8.0 (2018-03-22)
 
 This release was possible thanks to the help of some great contributors! Special thanks to [@clarkd](http://github.com/clarkd),

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ We all know BitBucket lacks some features that we have in other platforms like G
 *   Diff Ignore. Add filename patterns in the Options page that you would like the extension to completely remove when the pull request or commit loads.
 *   Counters for open or active branches and pull requests in the sidebar navigation menu.
 *   Button to load all failed diffs in pull request and commit view.
+*   Adds 'Create Pull Request' link to the 'Compare branches and tags' page.
 *   Choose a default merge strategy for your pull requests.
 *   Check the "Close anchor branch" checkbox by default when creating or editing pull requests.
 *   Add source branch, linkify branch names, and add creation date to each pull request row in pull request list.

--- a/src/background.js
+++ b/src/background.js
@@ -25,6 +25,7 @@ new OptionsSync().define({
         addSidebarCounters: true,
         diffPlusesAndMinuses: true,
         augmentPrEntry: true,
+        comparePagePullRequest: true,
         prTemplateEnabled: true,
         pullrequestCommitAmount: true,
         defaultMergeStrategy: 'merge_commit',

--- a/src/compare-page-pull-request/compare-page-pull-request.js
+++ b/src/compare-page-pull-request/compare-page-pull-request.js
@@ -1,0 +1,75 @@
+'use strict';
+
+import { h } from 'dom-chef';
+import 'selector-observer';
+import { getRepoURL } from '../page-detect';
+
+const COMPARE_DETAILS_SELECTOR = '#branch-compare.content-container';
+
+export default function comparePagePullRequest() {
+    /*
+     * Changes to the compare details selector indicate that either:
+     *  1) The Compare button has been hit for the first time
+     *  2) The branches that are being compared have changed
+     */
+    document.body.observeSelector(COMPARE_DETAILS_SELECTOR, addUrlIfComparing);
+}
+
+function addUrlIfComparing() {
+    const { source, destination } = getSourceAndDestination();
+
+    if (source && destination) {
+        addPRLink(source, destination);
+    }
+}
+
+export function addPRLink(source, destination, comparePage = document.body) {
+    // Get compare branches area
+    const detailSummarySection = comparePage.querySelector(
+        'ul.detail-summary--section'
+    );
+    const url = getPullRequestUrl(source, destination);
+
+    // Remove Create PR link URL if it already exists
+    const previousLink = detailSummarySection.querySelector(
+        '.js-pr-create-item'
+    );
+    if (previousLink) {
+        previousLink.parentNode.removeChild(previousLink);
+    }
+
+    const link = (
+        <li className="detail-summary--item js-pr-create-item">
+            <span
+                className="aui-icon aui-icon-small aui-iconfont-devtools-pull-request detail-summary--icon"
+                title="Pull requests"
+            >
+                Pull requests
+            </span>
+            <a href={url} title="Create a pull request">
+                Create pull request
+            </a>
+        </li>
+    );
+    detailSummarySection.appendChild(link, detailSummarySection);
+    return link;
+}
+
+function getPullRequestUrl(source, destination) {
+    return `https://bitbucket.org/${getRepoURL()}/pull-requests/new?source=${encodeURIComponent(
+        source
+    )}&dest=${encodeURIComponent(destination)}`;
+}
+
+function getSourceAndDestination() {
+    // This element contains all metadata about any current compare
+    const branchCompare = document.querySelector(COMPARE_DETAILS_SELECTOR);
+
+    // Get source and destination branch from data attributes
+    const {
+        compareSourceValue: source,
+        compareDestValue: destination
+    } = branchCompare.dataset;
+
+    return { source, destination };
+}

--- a/src/compare-page-pull-request/compare-page-pull-request.spec.js
+++ b/src/compare-page-pull-request/compare-page-pull-request.spec.js
@@ -1,0 +1,39 @@
+import { h } from 'dom-chef';
+import test from 'ava';
+
+import '../../test/setup-jsdom';
+
+import { addPRLink } from './compare-page-pull-request';
+
+test('mergePagePullRequest should add a create pull request link', t => {
+    const comparePage = (
+        <div class="detail-summary--panel" data-contributors="[]">
+            <ul class="detail-summary--section" />
+        </div>
+    );
+
+    const comparePageAddPR = (
+        <div class="detail-summary--panel" data-contributors="[]">
+            <ul class="detail-summary--section">
+                <li class="detail-summary--item js-pr-create-item">
+                    <span
+                        class="aui-icon aui-icon-small aui-iconfont-devtools-pull-request detail-summary--icon"
+                        title="Pull requests"
+                    >
+                        Pull requests
+                    </span>
+                    <a
+                        href="https://bitbucket.org//pull-requests/new?source=TEST_SOURCE&amp;dest=TEST_DESTINATION"
+                        title="Create a pull request"
+                    >
+                        Create pull request
+                    </a>
+                </li>
+            </ul>
+        </div>
+    );
+
+    addPRLink('TEST_SOURCE', 'TEST_DESTINATION', comparePage);
+
+    t.is(comparePage.outerHTML, comparePageAddPR.outerHTML);
+});

--- a/src/compare-page-pull-request/index.js
+++ b/src/compare-page-pull-request/index.js
@@ -1,0 +1,1 @@
+export { default } from './compare-page-pull-request';

--- a/src/main.js
+++ b/src/main.js
@@ -19,6 +19,7 @@ import pullrequestCommitAmount from './pullrequest-commit-amount';
 import insertPullrequestTemplate from './pullrequest-template';
 import addSidebarCounters from './sidebar-counters';
 import syntaxHighlight from './syntax-highlight';
+import comparePagePullRequest from './compare-page-pull-request';
 
 import observeForWordDiffs from './observe-for-word-diffs';
 
@@ -27,7 +28,8 @@ import {
     isCreatePullRequestURL,
     isPullRequestList,
     isCommit,
-    isBranch
+    isBranch,
+    isComparePage
 } from './page-detect';
 
 import 'selector-observer';
@@ -60,6 +62,10 @@ function init(config) {
         }
     } else if (isCommit()) {
         codeReviewFeatures(config);
+    } else if (isComparePage()) {
+        if (config.comparePagePullRequest) {
+            comparePagePullRequest();
+        }
     }
 
     if (config.improveFonts) {

--- a/src/options.html
+++ b/src/options.html
@@ -70,6 +70,12 @@
         <br>
 
         <label>
+            <input type="checkbox" name="comparePagePullRequest"> Add the 'Create a Pull Request' button to the 'Compare branches and tags' page view.
+        </label>
+        <br>
+        <br>
+
+        <label>
             <input type="checkbox" name="diffPlusesAndMinuses"> Don't carry pluses and minuses to clipboard when copying diff's contents
         </label>
         <br>

--- a/src/page-detect.js
+++ b/src/page-detect.js
@@ -23,6 +23,8 @@ export const isPullRequestList = () => getRepoPath() === 'pull-requests';
 
 export const isPullRequest = () => /^pull-requests\/\d+/.test(getRepoPath());
 
+export const isComparePage = () => /^branches\/compare/.exec(getRepoPath());
+
 export const isCreatePullRequestURL = () =>
     getRepoPath() === 'pull-requests/new';
 


### PR DESCRIPTION
<!--
    Check those that apply, and delete the ones that don't
-->
*   [x]  I updated the CHANGELOG.md
*   [x] I tested the changes in this pull request myself
*   [x] I added Automated Tests
*   [x] I updated the README.md, with pictures if necessary
*   [x] I added an Option to enable / disable this feature

Sorry to spam PRs, I didn't realise squashing a closed PR prevents it from being reopened. The old PR was https://github.com/refined-bitbucket/refined-bitbucket/pull/190

<img width="1110" alt="screen shot 2018-03-22 at 23 09 04" src="https://user-images.githubusercontent.com/9140708/37803338-18ec6444-2e26-11e8-866d-127ed36fb83e.png">

When clicked it'll show:

<img width="821" alt="screen shot 2018-03-22 at 23 10 11" src="https://user-images.githubusercontent.com/9140708/37803362-34bb8862-2e26-11e8-83c1-6d15ac0d0bf5.png">

I took a look at testing, it would have been nicer to mock the `isComparing` method rather than pass its source and destination through.

Closes #189 
---
