### PR TITLE
Add .cls as a java syntax formatted

### DIFF
--- a/src/syntax-highlight/language-ext.js
+++ b/src/syntax-highlight/language-ext.js
@@ -16,6 +16,7 @@ module.exports = {
     '.cc': 'language-cpp',
     '.cfc': 'language-actionscript',
     '.cfm': 'language-markup',
+    '.cls': 'language-java',
     '.coffee': 'language-coffeescript',
     '.config': 'language-markup',
     '.cs': 'language-csharp',


### PR DESCRIPTION
.cls is used for salesforce apex code which is a syntax clone of java.

<!--
    Check those that apply, and delete the ones that don't
-->

*   [ ] I updated the CHANGELOG.md
*   [ ] I tested the changes in this pull request myself
*   [ ] I added Automated Tests
*   [ ] I added an Option to enable / disable this feature
*   [ ] I updated the README.md, with pictures if necessary

---
