### PR TITLE
Custom Tab Indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ We all know BitBucket lacks some features that we have in other platforms like G
 
     _Note: Currently, externally hosted pull request templates outside of BitBucket's domain is not supported with the Firefox addon._
 
+*   Set custom tab indentation size of code (Bitbucket defaults to 8 spaces) when viewing commits/pull requests.
+
 ## Some images
 
 <table>

--- a/src/background.js
+++ b/src/background.js
@@ -36,6 +36,8 @@ new OptionsSync().define({
         ].join('\n'),
         autocollapseDeletedFiles: true,
         ignorePaths: [''].join('\n'),
+        customTabSizeEnabled: true,
+        customTabSize: 4,
         eneableUpdateNotifications: true
     },
     migrations: [

--- a/src/background.js
+++ b/src/background.js
@@ -38,11 +38,11 @@ new OptionsSync().define({
         ignorePaths: [''].join('\n'),
         customTabSizeEnabled: true,
         customTabSize: 4,
-        eneableUpdateNotifications: true
+        enableUpdateNotifications: true
     },
     migrations: [
         async savedOptions => {
-            if (savedOptions.eneableUpdateNotifications) {
+            if (savedOptions.enableUpdateNotifications) {
                 await justInstalledOrUpdated;
                 window.open(
                     'https://github.com/refined-bitbucket/refined-bitbucket/releases/latest'

--- a/src/main.js
+++ b/src/main.js
@@ -20,6 +20,7 @@ import insertPullrequestTemplate from './pullrequest-template';
 import addSidebarCounters from './sidebar-counters';
 import syntaxHighlight from './syntax-highlight';
 import comparePagePullRequest from './compare-page-pull-request';
+import setTabSize from './tab-size';
 
 import observeForWordDiffs from './observe-for-word-diffs';
 
@@ -74,6 +75,11 @@ function init(config) {
 
     if (config.addSidebarCounters) {
         addSidebarCounters();
+    }
+
+    if (config.customTabSizeEnabled) {
+        const numSpaces = config.customTabSize;
+        setTabSize(numSpaces);
     }
 }
 

--- a/src/options.html
+++ b/src/options.html
@@ -148,7 +148,7 @@
                 Enable Update Notifications. Every time this extension is updated, the CHANGELOG for the current version will be opened in
                 a new browser tab.
             </span>
-            <input type="checkbox" name="eneableUpdateNotifications">
+            <input type="checkbox" name="enableUpdateNotifications">
         </label>
     </form>
 

--- a/src/options.html
+++ b/src/options.html
@@ -135,6 +135,13 @@
         </div>
 
         <br>
+
+        <label>
+            <input type="checkbox" name="customTabSizeEnabled"> Tab indentation size:
+            <input type="number" name="customTabSize" min="0" max="16" style="width: 40px;">
+            <span>spaces.</span>
+        </label>
+
         <hr>
         <label style="display: flex; justify-content: space-between; align-items: center">
             <span style="width: calc(100% - 30px)">

--- a/src/tab-size/index.js
+++ b/src/tab-size/index.js
@@ -1,0 +1,1 @@
+export { default } from './tab-size';

--- a/src/tab-size/tab-size.js
+++ b/src/tab-size/tab-size.js
@@ -1,0 +1,21 @@
+export default function setTabSize(numSpaces) {
+    const cssRule = createCssRule(numSpaces);
+    addStyleToPage(cssRule);
+}
+
+function createCssRule(numSpaces) {
+    const rule = `
+        .refract-container {
+            tab-size: ${numSpaces}
+        }
+    `;
+    return rule;
+}
+
+// inject CSS <style> into <head> of page
+function addStyleToPage(rule) {
+    const css = document.createElement('style');
+    css.type = 'text/css';
+    css.appendChild(document.createTextNode(rule));
+    document.getElementsByTagName('head')[0].appendChild(css);
+}


### PR DESCRIPTION
Finished allowing custom tab indentation!   This is just a simple CSS injection.

This only applies to the commit and pull request view, it looks like in the past week or so bitbucket has changed their UI, so the "source" view is different now.  (and breaks some parts of this extension, like the syntax highlighting changes).  

I didn't update the changelog, because I wasn't sure if you wanted me to, but I can.  And I didn't add any automated tests because I felt it wouldn't be appropriate for just CSS. 

*   [x] I tested the changes in this pull request myself
*   [x] I added an Option to enable / disable this feature
*   [x] I updated the README.md, with pictures if necessary

Closes #202 