### PR TITLE
fix: Should not add extra leading whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 *   **Autocollapse**: Autocollapse feature shouldn't depend on "Toggle diff text" feature to work,
     closes [issue #221](https://github.com/refined-bitbucket/refined-bitbucket/issues/221),
     [pull request #224](https://github.com/refined-bitbucket/refined-bitbucket/pull/224).
+*   Fixed extra leading whitespacen in diffs when "Don't carry pluses and minuses to clipboard"
+    feature is enabled,
+    closes [issue #218](https://github.com/refined-bitbucket/refined-bitbucket/issues/218),
+    [pull request #226](https://github.com/refined-bitbucket/refined-bitbucket/pull/226).
 
 # 3.10.0 (2018-05-28)
 

--- a/src/diff-pluses-and-minuses/diff-pluses-and-minuses.js
+++ b/src/diff-pluses-and-minuses/diff-pluses-and-minuses.js
@@ -11,14 +11,14 @@ const stripCharsFromLine = line => {
     if (line.textContent === '+' || line.textContent === '-') {
         line.textContent = ' '
     } else {
-        line.textContent = line.textContent.slice(1)
+        line.innerHTML = line.innerHTML.slice(1)
     }
 }
 
 const firstPass = diff => {
     const diffLines = [...diff.querySelectorAll(diffLineSelector)]
 
-    diffLines.forEach(({ firstChild: line }) => stripCharsFromLine(line))
+    diffLines.forEach(line => stripCharsFromLine(line))
 
     return diffLines.map(({ textContent }) => textContent)
 }
@@ -26,7 +26,7 @@ const firstPass = diff => {
 const secondPass = (diff, strippedLinesContent) => {
     Array.from(diff.querySelectorAll(diffLineSelector))
         .filter(({ textContent }, i) => textContent !== strippedLinesContent[i])
-        .forEach(({ firstChild: line }) => stripCharsFromLine(line))
+        .forEach(line => stripCharsFromLine(line))
 }
 
 export default function removeDiffsPlusesAndMinuses(

--- a/src/diff-pluses-and-minuses/diff-pluses-and-minuses.spec.js
+++ b/src/diff-pluses-and-minuses/diff-pluses-and-minuses.spec.js
@@ -231,3 +231,40 @@ test('should do nothing and not throw or error when diff fails to load', async t
 
     t.is(udiff.outerHTML, expected.outerHTML)
 })
+
+test('should not add extra leading whitespace', t => {
+    const udiff = (
+        <section class="bb-udiff" data-filename="filename.js">
+            <div class="refract-content-container">
+                <div class="udiff-line deletion">
+                    <pre class="source">-class App extends Component </pre>
+                </div>
+
+                <div class="udiff-line addition">
+                    <pre class="source">
+                        +<ins>export default </ins>class App extends Component{' '}
+                    </pre>
+                </div>
+            </div>
+        </section>
+    )
+
+    const expected = (
+        <section class="bb-udiff" data-filename="filename.js">
+            <div class="refract-content-container">
+                <div class="udiff-line deletion">
+                    <pre class="source">class App extends Component </pre>
+                </div>
+                <div class="udiff-line addition">
+                    <pre class="source">
+                        <ins>export default </ins>class App extends Component{' '}
+                    </pre>
+                </div>
+            </div>
+        </section>
+    )
+
+    removeDiffsPlusesAndMinuses(udiff)
+
+    t.is(udiff.outerHTML, expected.outerHTML)
+})


### PR DESCRIPTION
This happened when the "Don't carry pluses and minuses to clipboard"
feature is enabled and the first characters of a diff line are
highlighted as inserted or deleted with `<ins>/<del>` tags.

Closes #218

*   [x] I updated the CHANGELOG.md
*   [x] I tested the changes in this pull request myself
*   [x] I added Automated Tests