### PR TITLE
feat: Custom CSS styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Features
 
+*   **Custom styles**: Now it's possible to define your own CSS styles to be applied to Bitbucket using the extension through the Options page,
+    closes [issue #181](https://github.com/refined-bitbucket/refined-bitbucket/issues/181),
+    [pull request #227](https://github.com/refined-bitbucket/refined-bitbucket/pull/227).
 *   **Default-merge-strategy**: Add "Fast forward" as a possible default merge strategy for pull requests,
     [pull request #222](https://github.com/refined-bitbucket/refined-bitbucket/pull/222).
 *   Code review features (syntax highlighting, occurrences highlighting, diff collapsing, etc.) now work in

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ We all know BitBucket lacks some features that we have in other platforms like G
 *   Set custom tab indentation size of code (Bitbucket defaults to 8 spaces) when viewing commits/pull requests.
 *   Insert "Comments" checkbox in diff header to toggle comments.
 *   Insert "Copy filename to clipboard" button in diff header.
+*   Define your own custom CSS styles to be applied to Bitbucket.
 *   Include a `PULL_REQUEST_TEMPLATE.md` file in the default branch of the repository in one of the locations below, and the contents of that file template will replace the default pull request body inserted by Bitbucket when creating a new one.
 
     ```

--- a/src/add-style.js
+++ b/src/add-style.js
@@ -1,0 +1,7 @@
+// inject CSS <style> into <head> of page
+export default function addStyleToPage(cssRule) {
+    const css = document.createElement('style')
+    css.type = 'text/css'
+    css.appendChild(document.createTextNode(cssRule))
+    document.getElementsByTagName('head')[0].appendChild(css)
+}

--- a/src/background.js
+++ b/src/background.js
@@ -22,7 +22,6 @@ new OptionsSync().define({
         collapseDiff: true,
         loadAllDiffs: true,
         closeAnchorBranch: true,
-        improveFonts: true,
         addSidebarCounters: true,
         diffPlusesAndMinuses: true,
         augmentPrEntry: true,
@@ -40,6 +39,7 @@ new OptionsSync().define({
         ignorePaths: [''].join('\n'),
         customTabSizeEnabled: true,
         customTabSize: 4,
+        customStyles: '',
         enableUpdateNotifications: true,
     },
     migrations: [

--- a/src/improve-fonts.css
+++ b/src/improve-fonts.css
@@ -1,5 +1,0 @@
-pre {
-    font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier,
-        monospace !important;
-    font-size: 16px;
-}

--- a/src/main.js
+++ b/src/main.js
@@ -35,6 +35,8 @@ import {
     isComparePage,
 } from './page-detect'
 
+import addStyleToPage from './add-style'
+
 import 'selector-observer'
 
 new OptionsSync().getAll().then(options => {
@@ -73,10 +75,6 @@ function init(config) {
         }
     }
 
-    if (config.improveFonts) {
-        require('./improve-fonts.css')
-    }
-
     if (config.addSidebarCounters) {
         addSidebarCounters()
     }
@@ -84,6 +82,10 @@ function init(config) {
     if (config.customTabSizeEnabled) {
         const numSpaces = config.customTabSize
         setTabSize(numSpaces)
+    }
+
+    if (config.customStyles) {
+        addStyleToPage(config.customStyles)
     }
 }
 

--- a/src/options.html
+++ b/src/options.html
@@ -7,7 +7,7 @@
 </head>
 
 <body>
-    <form id="options-form">
+    <form id="options-form" style="width: 600px">
         <label>
             <input type="checkbox" name="syntaxHighlight"> Syntax highlighting
         </label>
@@ -46,12 +46,6 @@
 
         <label>
             <input type="checkbox" name="closeAnchorBranch"> Check the "Close anchor branch" checkbox by default when creating a new pull request
-        </label>
-        <br>
-        <br>
-
-        <label>
-            <input type="checkbox" name="improveFonts"> Improve the default font-family and size of lines of code in Source view.
         </label>
         <br>
         <br>
@@ -135,7 +129,7 @@
                     <br> The files that match the given patterns will be automatically collapsed when the Pull Request loads.
                 </label>
             </div>
-            <textarea name="autocollapsePaths" rows="7" cols="60"></textarea>
+            <textarea name="autocollapsePaths" rows="7" style="width: 100%"></textarea>
             <br>
             <label>
                 <input type="checkbox" name="autocollapseDeletedFiles"> Autocollapse deleted files
@@ -152,7 +146,17 @@
                     </div>
                 </label>
             </div>
-            <textarea name="ignorePaths" rows="7" cols="60"></textarea>
+            <textarea name="ignorePaths" rows="7" style="width: 100%"></textarea>
+        </div>
+        <br>
+
+        <div>
+            <div>
+                <label>
+                    <strong>Define your own CSS styles to be injected in every page</strong>
+                </label>
+            </div>
+            <textarea name="customStyles" rows="7" style="width: 100%"></textarea>
         </div>
         <br>
 

--- a/src/tab-size/tab-size.js
+++ b/src/tab-size/tab-size.js
@@ -1,3 +1,5 @@
+import addStyleToPage from '../add-style'
+
 export default function setTabSize(numSpaces) {
     const cssRule = createCssRule(numSpaces)
     addStyleToPage(cssRule)
@@ -10,12 +12,4 @@ function createCssRule(numSpaces) {
         }
     `
     return cssRule
-}
-
-// inject CSS <style> into <head> of page
-function addStyleToPage(cssRule) {
-    const css = document.createElement('style')
-    css.type = 'text/css'
-    css.appendChild(document.createTextNode(cssRule))
-    document.getElementsByTagName('head')[0].appendChild(css)
 }


### PR DESCRIPTION
Now it's possible to define your own CSS styles to be applied to
Bitbucket using the extension through the Options page.

Closes #181

![image](https://user-images.githubusercontent.com/7514993/42128815-2b080110-7c82-11e8-9b6e-092f4972bb10.png)

*   [x] I updated the CHANGELOG.md
*   [x] I tested the changes in this pull request myself
*   [x] I added an Option to enable / disable this feature
*   [x] I updated the README.md, with pictures if necessary
