### PR TITLE
Fix bad side-by-side scrolling performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Next Version
+
+### Bug Fixes
+
+*   Fix bad side-by-side scrolling performance with syntax highlighting enabled,
+    closes [issue #183](https://github.com/refined-bitbucket/refined-bitbucket/issues/183),
+    [pull request #233](https://github.com/refined-bitbucket/refined-bitbucket/pull/233).
+
 # 3.11.0 (2018-06-30)
 
 ### Features

--- a/src/syntax-highlight/syntax-highlight.js
+++ b/src/syntax-highlight/syntax-highlight.js
@@ -41,7 +41,9 @@ export default function syntaxHighlight(diff, afterWordDiff) {
     const $diff = $(diff)
     syntaxHighlightSourceCodeLines($diff)
 
-    afterWordDiff(() => syntaxHighlightSourceCodeLines($diff))
+    afterWordDiff(() => {
+        syntaxHighlightSourceCodeLines($diff)
+    })
 
     const codeContainer = diff.querySelector('.refract-content-container')
     codeContainerObserver.observe(codeContainer, { childList: true })
@@ -73,7 +75,11 @@ function syntaxHighlightSourceCodeLines($diff) {
     )
 
     sourceLines.forEach(preElement => {
-        Prism.highlightElement(preElement)
+        if (!preElement.firstChild.$$rbb_isSyntaxHighlighted) {
+            Prism.highlightElement(preElement)
+            // eslint-disable-next-line camelcase
+            preElement.firstChild.$$rbb_isSyntaxHighlighted = true
+        }
     })
 }
 
@@ -87,7 +93,10 @@ async function highlightSideDiffAsync({ languageClass, diffNodeSelector }) {
     syntaxHighlightSourceCodeLines($sideBySide)
 }
 
-async function listenForSideDiffScrollAsync(args) {
+async function listenForSideDiffScrollAsync({
+    languageClass,
+    diffNodeSelector,
+}) {
     const scrollersSelector = 'div.aperture-pane-scroller'
 
     await elementReady(scrollersSelector, { target: document })
@@ -100,7 +109,10 @@ async function listenForSideDiffScrollAsync(args) {
         })
     }
 
-    debouncedSideDiffHandler = debounce(() => highlightSideDiffAsync(args), 250)
+    debouncedSideDiffHandler = debounce(
+        () => highlightSideDiffAsync({ languageClass, diffNodeSelector }),
+        250
+    )
 
     scrollers.forEach(scroller => {
         scroller.addEventListener('scroll', debouncedSideDiffHandler)

--- a/src/syntax-highlight/syntax-highlight.spec.js
+++ b/src/syntax-highlight/syntax-highlight.spec.js
@@ -164,3 +164,8 @@ test('should not syntax-highlight if diff is in a not supported language', t => 
 
     t.is(uudiff.outerHTML, expected.outerHTML)
 })
+
+// eslint-disable-next-line no-warning-comments
+// TODO: Can't test the Prism's KeepMarkup plugin until `document.createRange`
+// is implemented in jsdom. Keep an eye on https://github.com/jsdom/jsdom/issues/317
+// This is needed to test that word diffs are preserved when syntax highlighting diffs


### PR DESCRIPTION
Every time there was a scroll event when the side-by-side pane was open,
all lines that had word-diffs in them (`<ins>` and `<del>` tags) would
get syntax-highlighted again, increasing the size of the DOM tree
unnecesarily and infinitely for those nodes. The more the user scrolled,
the bigger the memory and CPU consumption. This caused a tremendous
performance impact.

The logic of the syntax highlighting function was updated so that it adds
a boolean property to the first child of the source code line `<pre>`
DOM node, this property is then going to be used on each subsequent call
to determine if the given line should be highlighted again. It is done
this way because it is the contents of that `<pre>` tag that are mutated
when word diffing occurs, not the wrapping line itself.

Closes #183

*   [x] I updated the CHANGELOG.md
*   [x] I tested the changes in this pull request myself
