### PR TITLE
Add row with total lines added and removed in file summary list (#239)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Next Version
+
+### Features
+
+*   Adds a 'Total Lines Changed' row to the files summary list,
+    closes [issue#239](https://github.com/refined-bitbucket/refined-bitbucket/issues/239).
+
 # 3.12.0 (2018-07-21)
 
 ### Bug Fixes

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,8 +5,9 @@ Please try to keep the list in order.
 
 *   [Adam Pitzele](http://github.com/apitzele)
 *   [Andre](http://github.com/andremw)
+*   [Dave Clarke](https://github.com/clarkd)
 *   [Gregory McQuillan](http://github.com/hk0i)
+*   [Jesse Scott](http://github.com/JesseScott)
 *   [Rodrigo Proença](http://github.com/rproenca)
 *   [Ronald Rey](http://github.com/reyronald)
-*   [Jesse Scott](http://github.com/JesseScott)
-*   [Dave Clarke](https://github.com/clarkd)
+*   [Travis Pett](https://github.com/travispett)

--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ We all know BitBucket lacks some features that we have in other platforms like G
 		<th colspan="2">
 			Sidebar counters
 		</th>
+        <th>
+            Total lines changed in diff
+        </th>
 	</tr>
 	<tr>
 		<td>
@@ -144,6 +147,9 @@ We all know BitBucket lacks some features that we have in other platforms like G
 			<img src="https://user-images.githubusercontent.com/7514993/35742830-1c604af8-0812-11e8-936b-f6083599fb45.png" alt="collapsed" /> <br />
 			Collapsed
 		</td>
+        <td>
+            <img src="https://user-images.githubusercontent.com/3758609/44361568-48e2cd00-a48c-11e8-9f6e-302e9a54fe24.png" alt="total-lines-changed-in-diff">
+        </td>
 	</tr>
 </table>
 

--- a/src/lines-added-removed/index.js
+++ b/src/lines-added-removed/index.js
@@ -1,0 +1,1 @@
+export { default } from './lines-added-removed'

--- a/src/lines-added-removed/lines-added-removed.js
+++ b/src/lines-added-removed/lines-added-removed.js
@@ -1,0 +1,53 @@
+'use strict'
+
+import elementReady from 'element-ready'
+import { h } from 'dom-chef'
+
+const sum = (num, currentSum) => num + currentSum
+
+const totalChangedLines = nodeList =>
+    Array.from(nodeList)
+        .map(span => Math.abs(parseInt(span.textContent, 10)))
+        .reduce(sum, 0)
+
+function totalStatRow(node) {
+    const linesAdded = totalChangedLines(
+        node.querySelectorAll('span.lines-added')
+    )
+    const linesRemoved = totalChangedLines(
+        node.querySelectorAll('span.lines-removed')
+    )
+
+    return (
+        <li
+            class="iterable-item file file-modified"
+            id="__refined_bitbucket_total_modified"
+        >
+            <div class="commit-file-diff-stats">
+                <span class="lines-added">+{linesAdded}</span>
+                <span class="lines-removed">-{linesRemoved}</span>
+            </div>
+            <span class="diff-summary-lozenge aui-lozenge aui-lozenge-subtle aui-lozenge-complete">
+                +/-
+            </span>
+            <span class="commit-files-summary--filename">
+                <b>Total Lines Changed</b>
+            </span>
+        </li>
+    )
+}
+
+export default async function linesAddedRemoved(node) {
+    // Wait for all sections to be loaded into the view
+    await elementReady('#commit-files-summary > li', {
+        target: node,
+    })
+
+    const filesSummary = node.querySelector('ul#commit-files-summary')
+
+    // Prepend a line with the total lines removed and added to the file summary list.
+    filesSummary.insertBefore(
+        totalStatRow(node),
+        filesSummary.firstElementChild
+    )
+}

--- a/src/lines-added-removed/lines-added-removed.spec.js
+++ b/src/lines-added-removed/lines-added-removed.spec.js
@@ -1,0 +1,50 @@
+import test from 'ava'
+import { h } from 'dom-chef'
+import elementReady from 'element-ready'
+
+import linesAddedRemoved from '.'
+
+import '../../test/setup-jsdom'
+
+function filesChangedNode(files) {
+    return (
+        <section id="main">
+            <ul id="commit-files-summary">
+                {files.map(file => (
+                    <li data-file-identifier={file.filename}>
+                        <span class="lines-added">+{file.linesAdded}</span>
+                        <span class="lines-removed">-{file.linesRemoved}</span>
+                        <a>{file.filename}</a>
+                    </li>
+                ))}
+            </ul>
+        </section>
+    )
+}
+
+test.serial('should prepend Total Lines Changed line when loaded', async t => {
+    const files = [
+        { filename: 'abcd.js', linesAdded: 25, linesRemoved: 20 },
+        { filename: 'Gemfile', linesAdded: 35, linesRemoved: 10 },
+    ]
+    const node = filesChangedNode(files)
+    linesAddedRemoved(node)
+
+    // Wait for the added/removed line to be prepended.
+    const addedRemoved = await elementReadyWithTimeout(
+        'li#__refined_bitbucket_total_modified',
+        { target: node }
+    )
+
+    const linesAdded = addedRemoved.querySelector('span.lines-added')
+    const linesRemoved = addedRemoved.querySelector('span.lines-removed')
+
+    t.is(Math.abs(parseInt(linesAdded.textContent, 10)), 60)
+    t.is(Math.abs(parseInt(linesRemoved.textContent, 10)), 30)
+})
+
+function elementReadyWithTimeout(selector, options, timeout = 1000) {
+    const promise = elementReady(selector, options)
+    setTimeout(promise.cancel, timeout)
+    return promise
+}

--- a/src/main.js
+++ b/src/main.js
@@ -13,6 +13,7 @@ import removeDiffsPlusesAndMinuses from './diff-pluses-and-minuses'
 import ignoreWhitespace from './ignore-whitespace'
 import insertCopyFilename from './insert-copy-filename'
 import keymap from './keymap'
+import linesAddedRemoved from './lines-added-removed'
 import linkifyTargetBranch from './linkify-target-branch'
 import loadAllDiffs from './load-all-diffs'
 import occurrencesHighlighter from './occurrences-highlighter'
@@ -121,6 +122,10 @@ function codeReviewFeatures(config) {
 
         if (config.loadAllDiffs) {
             loadAllDiffs.init(summaryNode)
+        }
+
+        if (config.linesAddedRemoved) {
+            linesAddedRemoved(summaryNode)
         }
     }
 

--- a/src/options.html
+++ b/src/options.html
@@ -33,6 +33,12 @@
         <br>
 
         <label>
+            <input type="checkbox" name="linesAddedRemoved" /> Enable "Total Lines Changed" row in files changed list
+        </label>
+        <br>
+        <br>
+
+        <label>
             <input type="checkbox" name="collapseDiff"> Add "Toggle diff text" button to collapse diff sections
         </label>
         <br>


### PR DESCRIPTION
Closes #239 

Adds a 'Total Lines Changed' row to the file summary list showing the sum of lines added and sum of lines removed. I elected to put the total row at the top of the files changed list for visibility.

<img width="324" alt="screen shot 2018-08-20 at 3 08 18 pm" src="https://user-images.githubusercontent.com/3758609/44361568-48e2cd00-a48c-11e8-9f6e-302e9a54fe24.png">

Also as a small cleanup, re-alphabetized `CONTRIBUTORS.md`

---

*   [x] I updated the CHANGELOG.md
*   [x] I tested the changes in this pull request myself
*   [x] I added Automated Tests
*   [x] I added an Option to enable / disable this feature
*   [x] I updated the README.md, with pictures if necessary