### PR TITLE
feat(augment-pr-entry): Include type of activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@
     closes [issue #97](https://github.com/refined-bitbucket/refined-bitbucket/issues/97),
     [pull request #243](https://github.com/refined-bitbucket/refined-bitbucket/pull/243).
 
+### Improvements
+
+-   **Augment PR Entry**: Besides indicating who was the last person to perform
+    any activity in the pull request in the pull request list view, also include what kind
+    of activity was it inside parenthesis. The possible values
+    are "Committed", "Commented" and "Approved",
+    [pull request #244](https://github.com/refined-bitbucket/refined-bitbucket/pull/244).
+
 # 3.12.0 (2018-07-21)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ We all know BitBucket lacks some features that we have in other platforms like G
 -   Adds 'Create Pull Request' link to the 'Compare branches and tags' page.
 -   Choose a default merge strategy for your pull requests. [Also implemented natively by Bitbucket per project](https://bitbucket.org/site/master/issues/13895/default-merge-strategy#comment-45364593)
 -   Check the "Close anchor branch" checkbox by default when creating or editing pull requests.
--   Add source branch, linkify branch names, and add creation date to each pull request row in pull request list.
+-   Add source branch, linkify branch names, add creation date and last person to interact with the pull request (commit, comment or approval) to each pull request row in pull request list.
 -   Don't carry pluses and minuses to clipboard when copying diff's contents.
 -   Badge with the number of commits of the current pull request next to the "Commits" tab.
 -   Set custom tab indentation size of code (Bitbucket defaults to 8 spaces) when viewing commits/pull requests.

--- a/src/augment-pr-entry/augment-pr-entry.js
+++ b/src/augment-pr-entry/augment-pr-entry.js
@@ -53,23 +53,27 @@ export const addUsernameWithLatestUpdate = async (prNode, prActivity) => {
     // pull requests by default have the initial commit info as an activity
     const mostRecentAction = prActivity.values[0]
     let author = ''
+    let activityType = ''
 
     // merges, commit updates
     if (mostRecentAction.update) {
         author = mostRecentAction.update.author.display_name
+        activityType = 'Committed'
     } else if (mostRecentAction.approval) {
         // approvals
         author = mostRecentAction.approval.user.display_name
+        activityType = 'Approved'
     } else if (mostRecentAction.comment) {
         // comments
         author = mostRecentAction.comment.user.display_name
+        activityType = 'Commented'
     }
 
     const prUpdateTime = prNode.querySelector('.pr-number-and-timestamp')
         .firstElementChild
 
     if (author && prUpdateTime) {
-        prUpdateTime.append(` by ${author}`)
+        prUpdateTime.append(` by ${author} (${activityType})`)
     }
 }
 

--- a/src/augment-pr-entry/augment-pr-entry.spec.js
+++ b/src/augment-pr-entry/augment-pr-entry.spec.js
@@ -206,6 +206,7 @@ test('addUsernameWithLatestUpdate should the name of author last update on succe
                         datetime="2018-02-23T09:52:37-0400"
                     >
                         last updated 39 minutes ago by Andrew Bernard
+                        (Committed)
                     </time>
                 </div>
             </tr>


### PR DESCRIPTION
Besides indicating who was the last person to perform
any activity in the pull request, also include what kind
of activity was it inside parenthesis. The possible values
are "Committed", "Commented" and "Approved".

Related to #142, #187.

-   [x] I updated the CHANGELOG.md
-   [x] I tested the changes in this pull request myself
-   [x] I added Automated Tests
-   [x] ~I added an Option to enable / disable this feature~ N/A
-   [x] I updated the README.md, with pictures if necessary

**Before**

![before](https://user-images.githubusercontent.com/7514993/44951233-fc54a580-ae2c-11e8-8f56-051ccc66f175.png)

**After**

![after](https://user-images.githubusercontent.com/7514993/44951212-412c0c80-ae2c-11e8-80ef-9bd459aad0ba.png)
