### PR TITLE
feat: Sticky header for diffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,31 @@
 # Next Version
 
-### Bug Fixes
-
--   Fixed an issue where deleted lines sometimes had a white background when using custom themes.
-    closes [issue#283](https://github.com/refined-bitbucket/refined-bitbucket/issues/283).
-
-# 3.17.0 (2019-05-17)
-
 ### Feature
 
 -   **Sticky Header**: The filename header for each file in a pull request will now remain visible for as long
     as the file is visible. This ensures that the filename can always be seen while content of that file is also
-    visible.
+    visible, [pull request #287](https://github.com/refined-bitbucket/refined-bitbucket/pull/287). Thanks [@denno020](https://github.com/denno020)
+
+### Bug Fixes
+
+-   Fix "Ignore Whitespace" feature that broke after Atlassian migrated their pull request list page
+    to a CSS-in-JS solution that autogenerates the CSS class names of the elements, making the
+    previous selectors the extension relied on useless,
+    closes [issue #285](https://github.com/refined-bitbucket/refined-bitbucket/issues/285),
+    [pull request #292](https://github.com/refined-bitbucket/refined-bitbucket/pull/292).
+
+# 3.17.0 (2019-06-03)
+
+### Improvements
+
+-   Add "None" option for the Default Merge Strategy feature, in case you don't want to use it,
+    closes [issue #288](https://github.com/refined-bitbucket/refined-bitbucket/issues/288),
+    [pull request #289](https://github.com/refined-bitbucket/refined-bitbucket/pull/289).
+
+### Bug Fixes
+
+-   Fixed an issue where deleted lines sometimes had a white background when using custom themes.
+    closes [issue #283](https://github.com/refined-bitbucket/refined-bitbucket/issues/283).
 
 # 3.16.0 (2019-04-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,16 @@
 
 ### Bug Fixes
 
-*   Fixed an issue where deleted lines sometimes had a white background when using custom themes.
+-   Fixed an issue where deleted lines sometimes had a white background when using custom themes.
     closes [issue#283](https://github.com/refined-bitbucket/refined-bitbucket/issues/283).
+
+# 3.17.0 (2019-05-17)
+
+### Feature
+
+-   **Sticky Header**: The filename header for each file in a pull request will now remain visible for as long
+    as the file is visible. This ensures that the filename can always be seen while content of that file is also
+    visible.
 
 # 3.16.0 (2019-04-21)
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ We all know BitBucket lacks some features that we have in other platforms like G
 
 -   Sticky Header filename toolbar
     While scrolling down viewing a large diff, the header of that diff, including the filename and actions, will remain visible## Some images
-    ![Sticky Header Small](https://user-images.githubusercontent.com/2059313/57961790-64fa9880-7950-11e9-9cf4-0f73104eb800.gif)
 
 ## Some images
 
@@ -154,6 +153,19 @@ We all know BitBucket lacks some features that we have in other platforms like G
 		<td>
 			<img src="https://user-images.githubusercontent.com/7514993/35742830-1c604af8-0812-11e8-936b-f6083599fb45.png" alt="collapsed" /> <br />
 			Collapsed
+		</td>
+	</tr>
+</table>
+
+<table>
+	<tr>
+		<th colspan="2">
+			Sticky Header
+		</th>
+	</tr>
+	<tr>
+		<td>
+			<img src="https://user-images.githubusercontent.com/2059313/57961790-64fa9880-7950-11e9-9cf4-0f73104eb800.gif" alt="Sticky Header"/>
 		</td>
 	</tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ We all know BitBucket lacks some features that we have in other platforms like G
 
 -   Sticky Header filename toolbar
     While scrolling down viewing a large diff, the header of that diff, including the filename and actions, will remain visible## Some images
+    ![Sticky Header Small](https://user-images.githubusercontent.com/2059313/57961790-64fa9880-7950-11e9-9cf4-0f73104eb800.gif)
 
 ## Some images
 

--- a/README.md
+++ b/README.md
@@ -58,10 +58,11 @@ We all know BitBucket lacks some features that we have in other platforms like G
 -   Similar to how the pull request template feature works,
     it is now possible to configure the extension to replace the default merge commit message for
     pull requests with a template that has access to dynamically injected variables like the pull
-    request title, description, source and destination branch, and more. [Click here for a more in-depth explanation](https://github.com/refined-bitbucket/refined-bitbucket/pull/243)
+    request title, description, source and destination branch, and more.
+    [Click here for a more in-depth explanation](https://github.com/refined-bitbucket/refined-bitbucket/pull/243)
 
--   Sticky Header filename toolbar
-    While scrolling down viewing a large diff, the header of that diff, including the filename and actions, will remain visible## Some images
+-   Sticky Header for diffs. While scrolling down viewing a large diff, the header of that diff,
+    including the filename and actions, will remain visible.
 
 ## Some images
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ We all know BitBucket lacks some features that we have in other platforms like G
     pull requests with a template that has access to dynamically injected variables like the pull
     request title, description, source and destination branch, and more. [Click here for a more in-depth explanation](https://github.com/refined-bitbucket/refined-bitbucket/pull/243)
 
+-   Sticky Header filename toolbar
+    While scrolling down viewing a large diff, the header of that diff, including the filename and actions, will remain visible## Some images
+
 ## Some images
 
 <table>

--- a/src/background.js
+++ b/src/background.js
@@ -46,14 +46,16 @@ new OptionsSync().define({
         customTabSize: 4,
         customStyles: '',
         enableUpdateNotifications: true,
+        stickyHeader: true,
     },
     migrations: [
         async savedOptions => {
             if (savedOptions.enableUpdateNotifications) {
                 await justInstalledOrUpdated
-                window.open(
-                    'https://github.com/refined-bitbucket/refined-bitbucket/releases/latest'
-                )
+                // DO NOT COMMIT THE FOLLOWING COMMENTED OUT CODE
+                // window.open(
+                //     'https://github.com/refined-bitbucket/refined-bitbucket/releases/latest'
+                // )
             }
         },
         OptionsSync.migrations.removeUnused,

--- a/src/background.js
+++ b/src/background.js
@@ -52,10 +52,9 @@ new OptionsSync().define({
         async savedOptions => {
             if (savedOptions.enableUpdateNotifications) {
                 await justInstalledOrUpdated
-                // DO NOT COMMIT THE FOLLOWING COMMENTED OUT CODE
-                // window.open(
-                //     'https://github.com/refined-bitbucket/refined-bitbucket/releases/latest'
-                // )
+                window.open(
+                    'https://github.com/refined-bitbucket/refined-bitbucket/releases/latest'
+                )
             }
         },
         OptionsSync.migrations.removeUnused,

--- a/src/main.js
+++ b/src/main.js
@@ -29,6 +29,7 @@ import comparePagePullRequest from './compare-page-pull-request'
 import setTabSize from './tab-size'
 import mergeCommitMessage from './merge-commit-message'
 import collapsePullRequestDescription from './collapse-pull-request-description'
+import setStickyHeader from './sticky-header'
 
 import observeForWordDiffs from './observe-for-word-diffs'
 
@@ -95,6 +96,10 @@ function init(config) {
 
     if (config.customStyles) {
         addStyleToPage(config.customStyles)
+    }
+
+    if (config.stickyHeader) {
+        setStickyHeader()
     }
 }
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Refined Bitbucket",
   "description": "Improves Bitbucket's user experience",
-  "version": "3.16.0",
+  "version": "3.17.0",
   "author": "Ronald Rey",
   "homepage_url": "https://github.com/refined-bitbucket/refined-bitbucket",
   "icons": {

--- a/src/options.html
+++ b/src/options.html
@@ -141,6 +141,14 @@
             <br />
 
             <label>
+                <input type="checkbox" name="stickyHeader" /> Sticky Header -
+                Ensure filename and actions toolbar is always visible even for
+                long diffs
+            </label>
+            <br />
+            <br />
+
+            <label>
                 <input type="checkbox" name="prTemplateEnabled" /> Use a
                 <em>PULL_REQUEST_TEMPLATE.md</em> from the repository when
                 creating new pull requests or specify a URL with your own raw

--- a/src/sticky-header/index.js
+++ b/src/sticky-header/index.js
@@ -1,0 +1,2 @@
+// @flow
+export { default } from './sticky-header'

--- a/src/sticky-header/sticky-header.js
+++ b/src/sticky-header/sticky-header.js
@@ -1,0 +1,25 @@
+// @flow
+
+import addStyleToPage from '../add-style'
+
+export default function setStickyHeader() {
+    const cssRule = createCssRule()
+    addStyleToPage(cssRule)
+}
+
+function createCssRule() {
+    const cssRule = `
+        .diff-container .heading {
+            position: sticky;
+            top: 0px;
+            z-index: 9;
+        }
+
+        @media (max-width: 979px) {
+            .diff-container .heading {
+                top: 54px;
+            }
+        }
+    `
+    return cssRule
+}

--- a/src/sticky-header/sticky-header.js
+++ b/src/sticky-header/sticky-header.js
@@ -13,6 +13,7 @@ function createCssRule() {
             position: sticky;
             top: 0px;
             z-index: 9;
+            border: 1px solid #DFE1E6;
         }
 
         @media (max-width: 979px) {


### PR DESCRIPTION
-   [✔] I updated the CHANGELOG.md
-   [✔] I tested the changes in this pull request myself
    - ~Whilst I did run the tests, I had multiple failures even before I changed anything, so I feel like I had an environment issue preventing me (I'm on Windows, so it's highly likely)~ *@reyronald: Fixed this for you*
-   [❌] I added Automated Tests
-   [✔] I added an Option to enable / disable this feature
-   [✔] I updated the README.md, with pictures if necessary

---

Please see animation below for explanation of the feature that has been added.

N.B. I have tried my best to only commit the lines that I've added for the CHANGELOG file, however for whatever reason, the white-space changes always go through. So the majority of the changes to the CHANGELOG file are removing trailing white-spaces, which probably shouldn't be there anyway

![Sticky Header Small](https://user-images.githubusercontent.com/2059313/57961790-64fa9880-7950-11e9-9cf4-0f73104eb800.gif)