### PR TITLE
feat: "None" option for default merge strategy ft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,15 @@
 # Next Version
 
+### Improvements
+
+-   Add "None" option for the Default Merge Strategy feature, in case you don't want to use it,
+    closes [issue #288](https://github.com/refined-bitbucket/refined-bitbucket/issues/288),
+    [pull request #289](https://github.com/refined-bitbucket/refined-bitbucket/pull/289).
+
 ### Bug Fixes
 
-*   Fixed an issue where deleted lines sometimes had a white background when using custom themes.
-    closes [issue#283](https://github.com/refined-bitbucket/refined-bitbucket/issues/283).
+-   Fixed an issue where deleted lines sometimes had a white background when using custom themes.
+    closes [issue #283](https://github.com/refined-bitbucket/refined-bitbucket/issues/283).
 
 # 3.16.0 (2019-04-21)
 

--- a/src/background.js
+++ b/src/background.js
@@ -34,7 +34,7 @@ new OptionsSync().define({
         mergeCommitMessageUrl: null,
         pullrequestCommitAmount: true,
         showCommentsCheckbox: true,
-        defaultMergeStrategy: 'merge_commit',
+        defaultMergeStrategy: 'none',
         autocollapsePaths: [
             'package-lock.json',
             'yarn.lock',

--- a/src/default-merge-strategy/default-merge-strategy.js
+++ b/src/default-merge-strategy/default-merge-strategy.js
@@ -6,7 +6,7 @@ import { h } from 'dom-chef'
 import logger from '../logger'
 import { isPullRequest } from '../page-detect'
 
-type Strategy = 'merge_commit' | 'squash' | 'fast_forward'
+type Strategy = 'none' | 'merge_commit' | 'squash' | 'fast_forward'
 
 declare var $: any
 
@@ -38,6 +38,10 @@ export function initAsync(defaultMergeStrategy: Strategy) {
             )
         }
 
+        if (defaultMergeStrategy === 'none') {
+            return resolve()
+        }
+
         // DefaultMergeStrategy can be either 'merge_commit', 'squash' or 'fast_forward'
         if (
             !['merge_commit', 'squash', 'fast_forward'].includes(
@@ -46,7 +50,7 @@ export function initAsync(defaultMergeStrategy: Strategy) {
         ) {
             const msg = `refined-bitbucket(default-merge-strategy): Unimplemented merge strategy '${defaultMergeStrategy}'. No action taken.`
             logger.warn(msg)
-            reject(msg)
+            return reject(msg)
         }
 
         const fulfillPr: HTMLElement = (document.getElementById(

--- a/src/main.js
+++ b/src/main.js
@@ -198,7 +198,9 @@ function codeReviewFeatures(config) {
 }
 
 function pullrequestRelatedFeatures(config) {
-    defaultMergeStrategy.init(config.defaultMergeStrategy)
+    if (config.defaultMergeStrategy !== 'none') {
+        defaultMergeStrategy.init(config.defaultMergeStrategy)
+    }
 
     if (config.keymap) {
         keymap.init()

--- a/src/options.html
+++ b/src/options.html
@@ -15,10 +15,11 @@
             <br />
 
             <label>
-                <input type="checkbox" name="autolinker"> Autolinker: Linkify links in diffs
+                <input type="checkbox" name="autolinker" /> Autolinker: Linkify
+                links in diffs
             </label>
-            <br>
-            <br>
+            <br />
+            <br />
 
             <label>
                 <input type="checkbox" name="highlightOcurrences" /> Highlight
@@ -42,8 +43,8 @@
             <br />
 
             <label>
-                <input type="checkbox" name="collapsePullRequestDescription" /> Add button to collapse
-                pull request descriptions
+                <input type="checkbox" name="collapsePullRequestDescription" />
+                Add button to collapse pull request descriptions
             </label>
             <br />
             <br />
@@ -190,6 +191,8 @@
                 name="default-merge-strategy-form"
                 style="margin: 0.5em 0 0 1em;"
             >
+                <input type="radio" name="defaultMergeStrategy" value="none" />
+                None
                 <input
                     type="radio"
                     name="defaultMergeStrategy"


### PR DESCRIPTION
Add "None" option to the default merge
strategy feature as a way to disable it.

Closes #288