### PR TITLE
lang: Add rudimentary Svelte syntax highlighting support

### DIFF
--- a/src/syntax-highlight/language-ext.js
+++ b/src/syntax-highlight/language-ext.js
@@ -77,6 +77,7 @@ module.exports = {
     '.snap': 'language-jsx',
     '.styl': 'language-stylus',
     '.svcmap': 'language-markup',
+    '.svelte': 'language-html',
     '.t': 'language-perl',
     '.tpl': 'language-smarty',
     '.trigger': 'language-java',


### PR DESCRIPTION
Hi! Added rudimentary support for syntax highlighting Svelte files by parsing them as HTML, which is a [solution that Svelte itself recommends](https://github.com/sveltejs/svelte/wiki/FAQ#how-can-i-get-vscode-to-syntax-highlight-my-svelte-files) when no better option is available.

Tested it on some Svelte files that I work with (in Firefox Developer edition). Can't post any screenshots because the project is confidential, but it works.

Could probably be improved upon the day that Svelte is added to [Prism's supported languages](https://prismjs.com/#supported-languages).

My first pull request, so I didn't dare to update the changelog. 

Solves #304

-   [x] I tested the changes in this pull request myself

---
