### PR TITLE
feat(limit-line-length): Show a ruler in unified diffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Feature
+
+-   Add a line length limit option that shows a ruler at the user-defined column.
+
 # 3.18.1 (2019-08-03)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ We all know BitBucket lacks some features that we have in other platforms like G
 -   Don't carry pluses and minuses to clipboard when copying diff's contents.
 -   Badge with the number of commits of the current pull request next to the "Commits" tab.
 -   Set custom tab indentation size of code (Bitbucket defaults to 8 spaces) when viewing commits/pull requests.
+-   Show a line length limit ruler, defaults to show in the 80th column
 -   Insert "Comments" checkbox in diff header to toggle comments.
 -   Insert "Copy filename to clipboard" button in diff header.
 -   Define your own custom CSS styles to be applied to Bitbucket.

--- a/README.md
+++ b/README.md
@@ -161,14 +161,20 @@ We all know BitBucket lacks some features that we have in other platforms like G
 
 <table>
 	<tr>
-		<th colspan="2">
+		<th width="50%">
 			Sticky Header
 		</th>
+        <th width="50%">
+            Line length limit ruler
+        </th>
 	</tr>
 	<tr>
 		<td>
 			<img src="https://user-images.githubusercontent.com/2059313/57961790-64fa9880-7950-11e9-9cf4-0f73104eb800.gif" alt="Sticky Header"/>
 		</td>
+        <td>
+            <img src="https://user-images.githubusercontent.com/12451101/71311094-cfaf0d80-2424-11ea-8bec-b1fdfded6c1e.png" alt="Line length limit ruler"/>
+        </td>
 	</tr>
 </table>
 

--- a/src/background.js
+++ b/src/background.js
@@ -44,6 +44,8 @@ new OptionsSync().define({
         ignorePaths: [''].join('\n'),
         customTabSizeEnabled: true,
         customTabSize: 4,
+        lineLengthLimitEnabled: true,
+        lineLengthLimit: 80,
         customStyles: '',
         enableUpdateNotifications: true,
         stickyHeader: true,

--- a/src/limit-line-length/index.js
+++ b/src/limit-line-length/index.js
@@ -1,0 +1,2 @@
+// @flow
+export { default } from './limit-line-length'

--- a/src/limit-line-length/limit-line-length.js
+++ b/src/limit-line-length/limit-line-length.js
@@ -1,0 +1,47 @@
+// @flow
+import addStyleToPage from '../add-style'
+
+function createCssRules(lineLengthLimit, isStickyHeaderEnabled) {
+    let filler = ''
+    for (let i = 0; i < lineLengthLimit; i++) {
+        filler += '#'
+    }
+
+    let cssRules = `
+        .refract-content-container > .udiff-line:first-child .source::before,
+        .refract-content-container > .udiff-line:last-child .source::before,
+        .refract-content-container > .udiff-line:nth-child(2):not(:last-child) .source::before {
+            content: "-${filler}";
+
+            position: absolute;
+            top: 0;
+            height: 100%;
+            border-right: 1px solid #c0c0c0;
+            pointer-events: none;
+            color: transparent;
+            user-select: none;
+        }
+    `
+
+    if (!isStickyHeaderEnabled) {
+        cssRules += `
+            .diff-container .heading {
+                position: relative;
+                z-index: 1;
+            }
+        `
+    }
+
+    return cssRules
+}
+
+export default function setLineLengthLimit(
+    lineLengthLimit: number | string,
+    isStickyHeaderEnabled: boolean
+) {
+    const cssRules = createCssRules(
+        parseInt(lineLengthLimit, 10),
+        isStickyHeaderEnabled
+    )
+    addStyleToPage(cssRules)
+}

--- a/src/main.js
+++ b/src/main.js
@@ -29,6 +29,7 @@ import setTabSize from './tab-size'
 import mergeCommitMessage from './merge-commit-message'
 import collapsePullRequestDescription from './collapse-pull-request-description'
 import setStickyHeader from './sticky-header'
+import setLineLengthLimit from './limit-line-length'
 
 import observeForWordDiffs from './observe-for-word-diffs'
 
@@ -200,6 +201,10 @@ function codeReviewFeatures(config) {
             }
         }
     )
+
+    if (config.lineLengthLimitEnabled) {
+        setLineLengthLimit(config.lineLengthLimit, config.stickyHeader)
+    }
 }
 
 function pullrequestRelatedFeatures(config) {

--- a/src/options.html
+++ b/src/options.html
@@ -135,6 +135,21 @@
             <br />
 
             <label>
+                <input type="checkbox" name="lineLengthLimitEnabled" />
+                Set a line limit of
+                <input
+                    type="number"
+                    name="lineLengthLimit"
+                    min="0"
+                    max="200"
+                    style="width: 40px;"
+                />
+                columns.
+            </label>
+            <br />
+            <br />
+
+            <label>
                 <input type="checkbox" name="showCommentsCheckbox" /> Insert
                 "Comments" checkbox in diff header to toggle comments.
             </label>


### PR DESCRIPTION
feat(limit-line-length): Show a ruler in unified diffs to mark the line length limit, configurable using a new line length limit option.

-   [x] I updated the CHANGELOG.md
-   [X] I tested the changes in this pull request myself
-   [X] I added an Option to enable / disable this feature
-   [X] I updated the README.md (without any pictures)

![image](https://user-images.githubusercontent.com/12451101/71311094-cfaf0d80-2424-11ea-8bec-b1fdfded6c1e.png)
