### PR TITLE
fix: Hide line-limit indicator in comments

### DIFF
--- a/src/limit-line-length/limit-line-length.js
+++ b/src/limit-line-length/limit-line-length.js
@@ -8,7 +8,7 @@ function createCssRules(lineLengthLimit, isStickyHeaderEnabled) {
     }
 
     let cssRules = `
-        .refract-content-container {
+        .refract-content-container, .comment-thread-container {
             position: relative;
         }
 

--- a/src/limit-line-length/limit-line-length.js
+++ b/src/limit-line-length/limit-line-length.js
@@ -8,6 +8,10 @@ function createCssRules(lineLengthLimit, isStickyHeaderEnabled) {
     }
 
     let cssRules = `
+        .refract-content-container {
+            position: relative;
+        }
+
         .refract-content-container > .udiff-line:first-child .source::before,
         .refract-content-container > .udiff-line:last-child .source::before,
         .refract-content-container > .udiff-line:nth-child(2):not(:last-child) .source::before {


### PR DESCRIPTION
<!--
    Check those that apply, and delete the ones that don't
-->

-   [ ] I updated the CHANGELOG.md
-   [x] I tested the changes in this pull request myself
-   [ ] I added Automated Tests
-   [ ] I added an Option to enable / disable this feature
-   [ ] I updated the README.md, with pictures if necessary

---
