### PR TITLE
Fixed limit-line-length bug that made line ruler show on top of file …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Bug Fixes
+
+-   Fix line ruler shows on top of file comments
+
 # 3.19.0 (2020-01-27)
 
 ### Features

--- a/src/limit-line-length/limit-line-length.js
+++ b/src/limit-line-length/limit-line-length.js
@@ -20,6 +20,12 @@ function createCssRules(lineLengthLimit, isStickyHeaderEnabled) {
             pointer-events: none;
             color: transparent;
             user-select: none;
+            z-index: 1;
+        }
+
+        .comment-thread-container {
+            position: relative;
+            z-index: 2;
         }
     `
 


### PR DESCRIPTION
…comments (and the edge of line comments)

thanks

Before:
![image](https://user-images.githubusercontent.com/12451101/73696770-aa7d1280-46e5-11ea-91f7-4d427534ef6c.png)

After:
![image](https://user-images.githubusercontent.com/12451101/73696814-c41e5a00-46e5-11ea-913a-92c4169f5241.png)

-   [X] I updated the CHANGELOG.md
-   [X] I tested the changes in this pull request myself
