### PR TITLE
enh: add user-select none to filename badge

### DIFF
--- a/src/insert-copy-filename/insert-copy-filename.css
+++ b/src/insert-copy-filename/insert-copy-filename.css
@@ -1,0 +1,4 @@
+/* fix ability to select filename correctly in a PR, removing Icon from being selected */
+.filename span {
+    user-select: none;
+}

--- a/src/insert-copy-filename/insert-copy-filename.js
+++ b/src/insert-copy-filename/insert-copy-filename.js
@@ -3,6 +3,8 @@
 
 import { h } from 'dom-chef'
 
+import './insert-copy-filename.css'
+
 function onClick() {
     const diff: HTMLElement = ((this: HTMLButtonElement).closest(
         '.bb-udiff'


### PR DESCRIPTION
> Issue #344 : maybe the button is not needed anymore

added `user-select:none` on badge and icon to make sure they are ignored when selecting the filename

so when double-clicking on a filename we now can select the same string that this feature copy
(i changed the icon on my branch for the add line to clipboard from atlassian-icon)
![image](https://user-images.githubusercontent.com/23088305/79253933-f5d43f80-7e51-11ea-9c57-08fa5d671e71.png)
`frontend/src/helpers/authorization/abilityActions.js ` (copied)

```
/* fix ability to select filename correctly in a PR, removing Icon from being selected */
.filename span {
    user-select: none;
}
```

