### PR TITLE
Adds new feature: New button in the New and Old UI Diff Viewers to Expand All Diff Sections

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,3 +10,4 @@ Please try to keep the list in order.
 -   [Ronald Rey](http://github.com/reyronald)
 -   [Jesse Scott](http://github.com/JesseScott)
 -   [Dave Clarke](https://github.com/clarkd)
+-   [Robert Christ](https://github.com/RobertChrist)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ We all know BitBucket lacks some features that we have in other platforms like G
 ## Current features
 
 -   Adds syntax highlighting for pull requests and commits. See the full list of enabled languages [here][prismjs-languages], and then [here][language-ext]. [Test them here](http://prismjs.com/test.html). Missing any language? [Let me know](https://github.com/refined-bitbucket/refined-bitbucket/issues) or submit a pull request!
+-   New button on diffs that expands every expandable section in the diff, with only one click!
 -   Double click on a word to highlight all occurrences.
 -   ~~Block pull request merging without a minimum number of approvals (defaults to 2 minimum approvals).~~ Removed. [Implemented natively by Bitbucket with "merge checks"](https://confluence.atlassian.com/bitbucketserver/checks-for-merging-pull-requests-776640039.html)
 -   Key binding feature, which allows for quicker navigation through pull requests.
@@ -175,6 +176,19 @@ We all know BitBucket lacks some features that we have in other platforms like G
         <td>
             <img src="https://user-images.githubusercontent.com/12451101/71311094-cfaf0d80-2424-11ea-8bec-b1fdfded6c1e.png" alt="Line length limit ruler"/>
         </td>
+	</tr>
+</table>
+
+<table>
+	<tr>
+		<th>
+			New Button That Expands All Expandable Diff Sections In One Click<br />
+		</th>
+	</tr>
+	<tr>
+		<td>
+			<img src="https://user-images.githubusercontent.com/1762464/95422415-4d3cff00-090d-11eb-803b-f5119278db2f.gif" alt="expand-diffs">
+		</td>
 	</tr>
 </table>
 

--- a/src/background.js
+++ b/src/background.js
@@ -19,6 +19,7 @@ new OptionsSync().define({
         highlightOcurrences: true,
         ignoreWhitespace: true,
         copyFilename: true,
+        expandDiffs: true,
         keymap: true,
         collapsePullRequestDescription: true,
         collapseDiff: true,

--- a/src/insert-copy-filename/insert-copy-filename.js
+++ b/src/insert-copy-filename/insert-copy-filename.js
@@ -47,6 +47,6 @@ export default function insertCopyFilename(diff: HTMLElement) {
     )
 
     const header: HTMLElement = (diff.querySelector('.filename'): any)
-    const lozenge: HTMLElement = (header.querySelector(':last-child'): any)
+    const lozenge: HTMLElement = (header.querySelector('h1 > :last-child'): any)
     header.insertBefore(button, lozenge)
 }

--- a/src/insert-expand-diff-new/index.js
+++ b/src/insert-expand-diff-new/index.js
@@ -1,0 +1,2 @@
+// @flow
+export { default } from './insert-expand-diff-new'

--- a/src/insert-expand-diff-new/insert-expand-diff-new.js
+++ b/src/insert-expand-diff-new/insert-expand-diff-new.js
@@ -1,0 +1,45 @@
+// @flow
+// @jsx h
+
+import { h } from 'dom-chef'
+
+function onClick(e, diff) {
+    e.stopPropagation()
+
+    const expandElipses = diff.querySelectorAll('button.show-more-lines-button')
+
+    if (!expandElipses) return
+
+    expandElipses.forEach(expander => expander.click())
+}
+
+export default function insertExpandDiffNew(diff: HTMLElement) {
+    const button = (
+        <button
+            type="button"
+            class="aui-button aui-button-subtle devtools-task-in-progress--button __rbb-btn-expandDiff"
+            title="Expand unexpanded diff sections once"
+            original-title="Expand unexpanded diff sections once"
+            style={{
+                position: 'relative',
+                border: 'none',
+                background: 'none',
+                cursor: 'pointer',
+            }}
+            onclick={e => onClick(e, diff)}
+        >
+            <span class="aui-icon aui-icon-small aui-iconfont-devtools-task-in-progress">
+                Load all diff sections, once
+            </span>
+        </button>
+    )
+
+    const header: ?HTMLElement = diff.querySelector("[data-qa='bk-filepath']")
+
+    if (!header) return
+
+    // $FlowIgnore If we found the header on the DOM, it will have a parent element.
+    const headerContainer: HTMLDivElement = header.parentElement
+
+    headerContainer.appendChild(button)
+}

--- a/src/insert-expand-diff-new/insert-expand-diff-new.js
+++ b/src/insert-expand-diff-new/insert-expand-diff-new.js
@@ -2,15 +2,28 @@
 // @jsx h
 
 import { h } from 'dom-chef'
+import SelectorObserver from 'selector-observer'
 
-function onClick(e, diff) {
+const _ellipsesSelector = 'button.show-more-lines-button'
+
+function queryForExpandButtons(diff) {
+    return diff.querySelectorAll(_ellipsesSelector)
+}
+
+function conditionallyDisableButton(diff, button) {
+    const newExpandEllipses = queryForExpandButtons(diff)
+
+    if (!newExpandEllipses || !newExpandEllipses.length) button.disabled = true
+}
+
+function onClick(e, diff: HTMLElement) {
     e.stopPropagation()
 
-    const expandElipses = diff.querySelectorAll('button.show-more-lines-button')
+    const expandEllipses = queryForExpandButtons(diff)
 
-    if (!expandElipses) return
+    if (!expandEllipses) return
 
-    expandElipses.forEach(expander => expander.click())
+    expandEllipses.forEach(expander => expander.click())
 }
 
 export default function insertExpandDiffNew(diff: HTMLElement) {
@@ -34,6 +47,8 @@ export default function insertExpandDiffNew(diff: HTMLElement) {
         </button>
     )
 
+    conditionallyDisableButton(diff, button)
+
     const header: ?HTMLElement = diff.querySelector("[data-qa='bk-filepath']")
 
     if (!header) return
@@ -42,4 +57,8 @@ export default function insertExpandDiffNew(diff: HTMLElement) {
     const headerContainer: HTMLDivElement = header.parentElement
 
     headerContainer.appendChild(button)
+
+    new SelectorObserver(diff, _ellipsesSelector, null, function() {
+        conditionallyDisableButton(diff, button)
+    })
 }

--- a/src/insert-expand-diff/index.js
+++ b/src/insert-expand-diff/index.js
@@ -1,0 +1,2 @@
+// @flow
+export { default } from './insert-expand-diff'

--- a/src/insert-expand-diff/insert-expand-diff.js
+++ b/src/insert-expand-diff/insert-expand-diff.js
@@ -2,16 +2,31 @@
 // @jsx h
 
 import { h } from 'dom-chef'
+import SelectorObserver from 'selector-observer'
 
-const onClick = (diff: HTMLElement) => {
-    const expandElipses = diff.querySelectorAll('.ellipsis')
+const _ellipsesSelector = '.ellipsis'
 
-    if (!expandElipses) return
+function queryForExpandButtons(diff) {
+    return diff.querySelectorAll(_ellipsesSelector)
+}
 
-    expandElipses.forEach(expander => expander.click())
+function conditionallyDisableButton(diff, button) {
+    const newExpandEllipses = queryForExpandButtons(diff)
+
+    if (!newExpandEllipses || !newExpandEllipses.length) button.disabled = true
+}
+
+function onClick(diff: HTMLElement) {
+    const expandEllipses = queryForExpandButtons(diff)
+
+    if (!expandEllipses) return
+
+    expandEllipses.forEach(expander => expander.click())
 }
 
 export default function insertExpandDiff(diff: HTMLElement) {
+    const expandEllipses = queryForExpandButtons(diff)
+
     const button = (
         <button
             type="button"
@@ -19,13 +34,15 @@ export default function insertExpandDiff(diff: HTMLElement) {
             title="Expand unexpanded diff sections once"
             original-title="Expand unexpanded diff sections once"
             style={{ position: 'relative' }}
-            onclick={() => onClick(diff)}
+            onclick={e => onClick(diff)}
         >
             <span class="aui-icon aui-icon-small aui-iconfont-devtools-task-in-progress">
                 Load all diff sections, once
             </span>
         </button>
     )
+
+    conditionallyDisableButton(diff, button)
 
     const header: ?HTMLElement = diff.querySelector('.filename')
 
@@ -36,4 +53,8 @@ export default function insertExpandDiff(diff: HTMLElement) {
     if (!lozenge) return
 
     header.insertBefore(button, lozenge)
+
+    new SelectorObserver(diff, _ellipsesSelector, null, function() {
+        conditionallyDisableButton(diff, button)
+    })
 }

--- a/src/insert-expand-diff/insert-expand-diff.js
+++ b/src/insert-expand-diff/insert-expand-diff.js
@@ -33,7 +33,12 @@ export default function insertExpandDiff(diff: HTMLElement) {
             class="aui-button aui-button-subtle devtools-task-in-progress--button __rbb-btn-expandDiff"
             title="Expand unexpanded diff sections once"
             original-title="Expand unexpanded diff sections once"
-            style={{ position: 'relative' }}
+            style={{
+                position: 'relative',
+                margin: '0',
+                paddingLeft: '5px',
+                paddingRight: '5px',
+            }}
             onclick={e => onClick(diff)}
         >
             <span class="aui-icon aui-icon-small aui-iconfont-devtools-task-in-progress">

--- a/src/insert-expand-diff/insert-expand-diff.js
+++ b/src/insert-expand-diff/insert-expand-diff.js
@@ -1,0 +1,39 @@
+// @flow
+// @jsx h
+
+import { h } from 'dom-chef'
+
+const onClick = (diff: HTMLElement) => {
+    const expandElipses = diff.querySelectorAll('.ellipsis')
+
+    if (!expandElipses) return
+
+    expandElipses.forEach(expander => expander.click())
+}
+
+export default function insertExpandDiff(diff: HTMLElement) {
+    const button = (
+        <button
+            type="button"
+            class="aui-button aui-button-subtle devtools-task-in-progress--button __rbb-btn-expandDiff"
+            title="Expand unexpanded diff sections once"
+            original-title="Expand unexpanded diff sections once"
+            style={{ position: 'relative' }}
+            onclick={() => onClick(diff)}
+        >
+            <span class="aui-icon aui-icon-small aui-iconfont-devtools-task-in-progress">
+                Load all diff sections, once
+            </span>
+        </button>
+    )
+
+    const header: ?HTMLElement = diff.querySelector('.filename')
+
+    if (!header) return
+
+    const lozenge: ?HTMLElement = header.querySelector('h1 > :last-child')
+
+    if (!lozenge) return
+
+    header.insertBefore(button, lozenge)
+}

--- a/src/insert-expand-diff/insert-expand-diff.spec.js
+++ b/src/insert-expand-diff/insert-expand-diff.spec.js
@@ -1,7 +1,7 @@
 import { h } from 'dom-chef'
 import test from 'ava'
 
-import insertCopyFilename from '.'
+import insertExpandDiff from '.'
 
 import '../../test/setup-jsdom'
 
@@ -51,13 +51,13 @@ const sectionWithButton = (
                         filename.js
                         <button
                             type="button"
-                            class="aui-button aui-button-subtle copy-to-clipboard--button __rbb-btn-copyfilename"
-                            title="Copy filename to clipboard"
-                            original-title="Copy filename to clipboard"
+                            class="aui-button aui-button-subtle devtools-task-in-progress--button __rbb-btn-expandDiff"
+                            title="Expand unexpanded diff sections once"
+                            original-title="Expand unexpanded diff sections once"
                             style={{ position: 'relative' }}
                         >
-                            <span class="aui-icon aui-icon-small aui-iconfont-copy-clipboard">
-                                Copy filename to clipboard
+                            <span class="aui-icon aui-icon-small aui-iconfont-devtools-task-in-progress">
+                                Load all diff sections, once
                             </span>
                         </button>
                         <span class="diff-entry-lozenge aui-lozenge aui-lozenge-subtle aui-lozenge-complete">
@@ -70,15 +70,15 @@ const sectionWithButton = (
     </section>
 )
 
-test('`insertCopyFilename` should insert button', t => {
+test('`insertExpandDiff` should insert button', t => {
     const diff = cleanSection.cloneNode(true)
 
-    insertCopyFilename(diff)
+    insertExpandDiff(diff)
 
     t.is(diff.outerHTML, sectionWithButton.outerHTML)
 })
 
-test('`insertCopyFilename` should insert a button, even if other buttons already exist', t => {
+test('`insertExpandDiff` should insert a button, even if other buttons already exist', t => {
     const sectionWithTwoButtons = (
         <section
             class="iterable-item bb-udiff maskable commentable-diff"
@@ -98,24 +98,24 @@ test('`insertCopyFilename` should insert a button, even if other buttons already
                             filename.js
                             <button
                                 type="button"
-                                class="aui-button aui-button-subtle copy-to-clipboard--button __rbb-btn-copyfilename"
-                                title="Copy filename to clipboard"
-                                original-title="Copy filename to clipboard"
+                                class="aui-button aui-button-subtle devtools-task-in-progress--button __rbb-btn-expandDiff"
+                                title="Expand unexpanded diff sections once"
+                                original-title="Expand unexpanded diff sections once"
                                 style={{ position: 'relative' }}
                             >
-                                <span class="aui-icon aui-icon-small aui-iconfont-copy-clipboard">
-                                    Copy filename to clipboard
+                                <span class="aui-icon aui-icon-small aui-iconfont-devtools-task-in-progress">
+                                    Load all diff sections, once
                                 </span>
                             </button>
                             <button
                                 type="button"
-                                class="aui-button aui-button-subtle copy-to-clipboard--button __rbb-btn-copyfilename"
-                                title="Copy filename to clipboard"
-                                original-title="Copy filename to clipboard"
+                                class="aui-button aui-button-subtle devtools-task-in-progress--button __rbb-btn-expandDiff"
+                                title="Expand unexpanded diff sections once"
+                                original-title="Expand unexpanded diff sections once"
                                 style={{ position: 'relative' }}
                             >
-                                <span class="aui-icon aui-icon-small aui-iconfont-copy-clipboard">
-                                    Copy filename to clipboard
+                                <span class="aui-icon aui-icon-small aui-iconfont-devtools-task-in-progress">
+                                    Load all diff sections, once
                                 </span>
                             </button>
                             <span class="diff-entry-lozenge aui-lozenge aui-lozenge-subtle aui-lozenge-complete">
@@ -130,7 +130,7 @@ test('`insertCopyFilename` should insert a button, even if other buttons already
 
     const diff = sectionWithButton.cloneNode(true)
 
-    insertCopyFilename(diff)
+    insertExpandDiff(diff)
 
     t.is(diff.outerHTML, sectionWithTwoButtons.outerHTML)
 })

--- a/src/main.js
+++ b/src/main.js
@@ -36,6 +36,8 @@ import mergeCommitMessageNew from './merge-commit-message-new'
 import collapsePullRequestDescription from './collapse-pull-request-description'
 import setStickyHeader from './sticky-header'
 import setLineLengthLimit from './limit-line-length'
+import insertExpandDiff from './insert-expand-diff'
+import insertExpandDiffNew from './insert-expand-diff-new'
 
 import observeForWordDiffs from './observe-for-word-diffs'
 
@@ -190,6 +192,10 @@ function codeReviewFeatures(config) {
             insertCopyFilename(diff)
         }
 
+        if (config.expandDiffs) {
+            insertExpandDiff(diff)
+        }
+
         if (config.diffPlusesAndMinuses || config.syntaxHighlight) {
             const afterWordDiff = observeForWordDiffs(diff)
 
@@ -263,7 +269,7 @@ function pullrequestRelatedFeaturesNew(config) {
         mergeCommitMessageNew(config.mergeCommitMessageUrl)
     }
 
-    if (config.copyFilename) {
+    if (config.copyFilename || config.expandDiffs) {
         // eslint-disable-next-line no-new
         new SelectorObserver(
             document.body,
@@ -271,6 +277,10 @@ function pullrequestRelatedFeaturesNew(config) {
             function() {
                 if (config.copyFilename) {
                     insertCopyFilenameNew(this)
+                }
+
+                if (config.expandDiffs) {
+                    insertExpandDiffNew(this)
                 }
             }
         )

--- a/src/options.html
+++ b/src/options.html
@@ -120,6 +120,13 @@
         <br />
 
         <label>
+            <input type="checkbox" name="expandDiffs" /> Insert "Expand all Diff Sections" button in diff
+            header
+        </label>
+        <br />
+        <br />
+
+        <label>
             <input type="checkbox" name="customTabSizeEnabled" /> Tab
             indentation size:
             <input type="number" name="customTabSize" min="0" max="16" style="width: 40px;" />


### PR DESCRIPTION
<!--
    Check those that apply, and delete the ones that don't
-->

-   [ ] I updated the CHANGELOG.md
-   [x] I tested the changes in this pull request myself
-   [x] I added Automated Tests
-   [x] I added an Option to enable / disable this feature
-   [x] I updated the README.md, with pictures if necessary

---

This PR adds a new button in the new and old UI diff viewers, next to the copy filename button, that when clicked, will click all of the individual "..." buttons in the diff.  So if your diff has 4 expandable "..." sections, clicking this button will save you 3 clicks.  

This is particularly useful for large files with lots of small edits, as those files tend to result in very disjointed and hard to read diffs, until you have expanded the diff enough to view a significant portion of the file.

<details>
  <summary>See GIF</summary>

![gif](https://user-images.githubusercontent.com/1762464/95422415-4d3cff00-090d-11eb-803b-f5119278db2f.gif)

</details>