### PR TITLE
Adds 'Compact' FileTree mode for 'new' Pull Request UI

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,3 +10,4 @@ Please try to keep the list in order.
 -   [Ronald Rey](http://github.com/reyronald)
 -   [Jesse Scott](http://github.com/JesseScott)
 -   [Dave Clarke](https://github.com/clarkd)
+-   [Robert Christ](https://github.com/RobertChrist)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ We all know BitBucket lacks some features that we have in other platforms like G
 ## Current features
 
 -   Adds syntax highlighting for pull requests and commits. See the full list of enabled languages [here][prismjs-languages], and then [here][language-ext]. [Test them here](http://prismjs.com/test.html). Missing any language? [Let me know](https://github.com/refined-bitbucket/refined-bitbucket/issues) or submit a pull request!
+-   Removes Whitespace from the FileTree Menu in the New PR UI (false by default, enable in extension options)
 -   Double click on a word to highlight all occurrences.
 -   ~~Block pull request merging without a minimum number of approvals (defaults to 2 minimum approvals).~~ Removed. [Implemented natively by Bitbucket with "merge checks"](https://confluence.atlassian.com/bitbucketserver/checks-for-merging-pull-requests-776640039.html)
 -   Key binding feature, which allows for quicker navigation through pull requests.
@@ -175,6 +176,19 @@ We all know BitBucket lacks some features that we have in other platforms like G
         <td>
             <img src="https://user-images.githubusercontent.com/12451101/71311094-cfaf0d80-2424-11ea-8bec-b1fdfded6c1e.png" alt="Line length limit ruler"/>
         </td>
+	</tr>
+</table>
+
+<table>
+	<tr>
+		<th>
+			Compact PR File Trees
+		</th>
+	</tr>
+	<tr>
+		<td>
+			<img src="https://user-images.githubusercontent.com/1762464/95523316-4dd0a680-099c-11eb-82f1-1aa8ceba90f6.png" alt="compactTree">
+		</td>
 	</tr>
 </table>
 

--- a/src/background.js
+++ b/src/background.js
@@ -15,6 +15,7 @@ const justInstalledOrUpdated = new Promise((resolve, reject) => {
 new OptionsSync().define({
     defaults: {
         syntaxHighlight: true,
+        compactFileTree: false,
         autolinker: true,
         highlightOcurrences: true,
         ignoreWhitespace: true,

--- a/src/compact-pull-request-file-tree/compact-pull-request-file-tree.js
+++ b/src/compact-pull-request-file-tree/compact-pull-request-file-tree.js
@@ -1,0 +1,22 @@
+// @flow
+
+import addStyleToPage from '../add-style'
+
+export default function setCompactPullRequestFileTree() {
+    const cssRule = createCssRule()
+    addStyleToPage(cssRule)
+}
+
+function createCssRule() {
+    const cssRule = `
+        #PullRequestWelcomeTourTarget-Files a {
+            height: 1em;
+            padding: 5px 4px;
+        }
+
+        #PullRequestWelcomeTourTarget-Files button {
+            padding: 5px 0;
+        }
+    `
+    return cssRule
+}

--- a/src/compact-pull-request-file-tree/index.js
+++ b/src/compact-pull-request-file-tree/index.js
@@ -1,0 +1,2 @@
+// @flow
+export { default } from './compact-pull-request-file-tree'

--- a/src/main.js
+++ b/src/main.js
@@ -36,6 +36,7 @@ import mergeCommitMessageNew from './merge-commit-message-new'
 import collapsePullRequestDescription from './collapse-pull-request-description'
 import setStickyHeader from './sticky-header'
 import setLineLengthLimit from './limit-line-length'
+import setCompactPRFileTree from './compact-pull-request-file-tree'
 
 import observeForWordDiffs from './observe-for-word-diffs'
 
@@ -274,6 +275,10 @@ function pullrequestRelatedFeaturesNew(config) {
                 }
             }
         )
+    }
+
+    if (config.compactFileTree) {
+        setCompactPRFileTree()
     }
 }
 

--- a/src/options.html
+++ b/src/options.html
@@ -16,6 +16,13 @@
         <br />
 
         <label>
+            <input type="checkbox" name="compactFileTree" /> Compact View Mode for PR FileTrees (Removes padding from
+            files, displays more files on screen)
+        </label>
+        <br />
+        <br />
+
+        <label>
             <input type="checkbox" name="autolinker" /> Autolinker: Linkify
             links in diffs
         </label>


### PR DESCRIPTION
<!--
    Check those that apply, and delete the ones that don't
-->

-   [ ] I updated the CHANGELOG.md
-   [x] I tested the changes in this pull request myself
-   [ ] I added Automated Tests
-   [x] I added an Option to enable / disable this feature
-   [x] I updated the README.md, with pictures if necessary

---

I added an (off by default) option that removes some of the whitespace from the new PR UI filetree component.  I added pictures to the README demonstrating the difference.  I have found this feature helpful for PRs with large amounts of files, and thought others might find it useful as well.  

<details>
  <summary>Screenshot</summary>

![ss](https://user-images.githubusercontent.com/1762464/95523316-4dd0a680-099c-11eb-82f1-1aa8ceba90f6.png)

</details>