### PR TITLE
Preserve word diffs when highlighting lines

### DIFF
--- a/src/syntax-highlight/syntax-highlight-new.js
+++ b/src/syntax-highlight/syntax-highlight-new.js
@@ -35,6 +35,7 @@ export default function syntaxHighlight(
     theme: string
 ) {
     loadThemeOnce(theme)
+    require('../vendor/prism-preserve-word-diffs')
 
     // Set up an observer to pay attention to all potential code changes in the diff section
     allDiffsObserver.observe(sectionAllDiffs, {

--- a/src/vendor/prism-preserve-word-diffs.js
+++ b/src/vendor/prism-preserve-word-diffs.js
@@ -7,7 +7,7 @@
 	
 	Prism.hooks.add('before-highlight', function (env) {
 		var elt = env.element;
-		if (!elt.hasAttribute('data-keep-tags') && elt.parentNode.tagName.toLowerCase() === 'pre') {
+		if (elt.parentNode.tagName.toLowerCase() === 'pre') {
 			elt = elt.parentNode;
 		}
 		var tags = ['del', 'ins']

--- a/src/vendor/prism-preserve-word-diffs.js
+++ b/src/vendor/prism-preserve-word-diffs.js
@@ -1,0 +1,59 @@
+(function () {
+	if (!self.Prism) {
+		return;
+	}
+
+	var div = document.createElement('div');
+	
+	Prism.hooks.add('before-highlight', function (env) {
+		var elt = env.element;
+		if (!elt.hasAttribute('data-keep-tags') && elt.parentNode.tagName.toLowerCase() === 'pre') {
+			elt = elt.parentNode;
+		}
+		var tags = ['del', 'ins']
+		if (!tags) {
+			return;
+		}
+		var placeholder = elt.getAttribute('data-keep-tags-placeholder') || '___KEEPTAGS{n}___';
+
+		env.keepTags = true;
+		env.keepTagsPlaceholder = placeholder;
+
+		tags = tags.join('|');
+		var tags_regex = RegExp('<(' + tags + ')>([\\s\\S]*?)</\\1>', 'g');
+
+		env.keepTagsRegex = tags_regex;
+
+		env.tokenStack = [];
+		env.backupCode = env.code;
+
+		var code = env.element.innerHTML;
+		code = code.replace(tags_regex, function (match) {
+			env.tokenStack.push(match);
+			return placeholder.replace('{n}', env.tokenStack.length);
+		});
+		env.element.innerHTML = code;
+		code = env.element.textContent;
+		code = code.replace(/^(?:\r?\n|\r)/,'');
+
+		env.code = code;
+	});
+
+	Prism.hooks.add('after-highlight', function (env) {
+		if (!env.keepTags) {
+			return;
+		}
+		for (var i = 0, t; t = env.tokenStack[i]; i++) {
+
+			t = t.replace(env.keepTagsRegex, function(match, tag, inside) {
+				div.innerHTML = inside;
+				inside = div.textContent;
+				return '<' + tag + '>' + Prism.highlight(inside, env.grammar, env.language) + '</' + tag + '>';
+			});
+
+			env.highlightedCode = env.highlightedCode.replace(env.keepTagsPlaceholder.replace('{n}', i + 1), t);
+			env.element.innerHTML = env.highlightedCode;
+		}
+	});
+
+}());


### PR DESCRIPTION
Bitbucket's new diff view has a feature where word diffs are highlighted with a darker shade of green red.
The current implementation strips out `del` and `ins` tags from the diff view.  

This PR preserves these tags, and hence word diffs.

### Before

<img width="924" alt="Screenshot 2021-05-14 at 11 15 04 PM" src="https://user-images.githubusercontent.com/8946207/118309003-482ad880-b50a-11eb-8de8-53b1ad477457.png">

### After
<img width="867" alt="Screenshot 2021-05-14 at 11 12 54 PM" src="https://user-images.githubusercontent.com/8946207/118309020-4c56f600-b50a-11eb-988f-f3385afb04f7.png">


-   [x] I tested the changes in this pull request myself