### PR TITLE
feat(total-lines-changed): add total lines added and removed for PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,19 @@ We all know BitBucket lacks some features that we have in other platforms like G
 	</tr>
 </table>
 
+<table>
+	<tr>
+		<th>
+            Show total lines added and removed for a pull request
+		</th>
+	</tr>
+	<tr>
+		<td>
+			<img src="https://user-images.githubusercontent.com/1710840/135918236-58e2b35b-18ad-4aba-b612-fb517b7533ba.png" alt="total lines added and removed for PR">
+		</td>
+	</tr>
+</table>
+
 ## Installing
 
 _refined-bitbucket_ is available on the [Google Chrome Web Store][chrome-install] and [Add-ons for Firefox][firefox-install]. When installed, go check the extension's Options to customize it to your needs.

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ We all know BitBucket lacks some features that we have in other platforms like G
 	</tr>
 	<tr>
 		<td>
-			<img src="https://user-images.githubusercontent.com/1710840/135918236-58e2b35b-18ad-4aba-b612-fb517b7533ba.png" alt="total lines added and removed for PR">
+			<img src="https://user-images.githubusercontent.com/1710840/135920358-b9d0b758-c325-466c-984e-ad9e1a61399a.png" alt="total lines added and removed for PR">
 		</td>
 	</tr>
 </table>

--- a/src/api.js
+++ b/src/api.js
@@ -25,13 +25,37 @@ export type PullRequest = {|
 export type PullRequestActivity = {|
     values: Array<
         | {|
-              update: { author: { display_name: string } },
+              update: {
+                  author: { display_name: string },
+                  destination: { commit: { hash: string, type: string } },
+              },
           |}
         | {|
               approval: { user: { display_name: string } },
           |}
         | {| comment: { user: { display_name: string } } |}
     >,
+|}
+
+// https://bitbucket.org/!api/2.0/repositories/%7Busername%7D/%7Brepo_slug%7D/pullrequests/%7DprId%7B/commits
+export type PullRequestCommits = {|
+    pagelen: number,
+    page: number,
+    values: Array<{|
+        hash: string,
+        type: string,
+        message: string,
+        date: string,
+    |}>,
+|}
+
+//
+export type PullRequestDiffStats = {|
+    size: number,
+    values: Array<{|
+        lines_added: number,
+        lines_removed: number,
+    |}>,
 |}
 
 const repoUrl = getRepoURL()
@@ -58,8 +82,15 @@ const api = {
     },
     getPullrequestCommits(
         id: number | string
-    ): Promise<{| size: number |} | void> {
+    ): Promise<PullRequestCommits | void> {
         return sendMessageCb('getPullrequestCommits', { id })
+    },
+    getPullrequestFiles(
+        id: number | string,
+        hash1: string,
+        hash2: string
+    ): Promise<PullRequestDiffStats | void> {
+        return sendMessageCb('getPullrequestFiles', { id, hash1, hash2 })
     },
 }
 

--- a/src/background-for-requests.js
+++ b/src/background-for-requests.js
@@ -24,6 +24,10 @@ type Request = { token: string, repoUrl: string } & (
           name: 'getPullrequestCommits',
           id: number | string,
       }
+    | {
+          name: 'getPullrequestFiles',
+          id: number | string,
+      }
 )
 
 // eslint-disable-next-line no-undef
@@ -44,10 +48,13 @@ chrome.runtime.onMessage.addListener(
                 url = `https://api.bitbucket.org/2.0/repositories/${repoUrl}/pullrequests/${id}`
             } else if (request.name === 'getPullrequestActivity') {
                 const { id } = request
-                url = `https://api.bitbucket.org/2.0/repositories/${repoUrl}/pullrequests/${id}/activity?pagelen=1`
+                url = `https://api.bitbucket.org/2.0/repositories/${repoUrl}/pullrequests/${id}/activity?pagelen=50`
             } else if (request.name === 'getPullrequestCommits') {
                 const { id } = request
                 url = `https://api.bitbucket.org/2.0/repositories/${repoUrl}/pullrequests/${id}/commits`
+            } else if (request.name === 'getPullrequestFiles') {
+                const { id, hash1, hash2 } = request
+                url = `https://bitbucket.org/!api/2.0/repositories/${repoUrl}/diffstat/${repoUrl}:${hash1}%0D${hash2}?from_pullrequest_id=${id}&pagelen=1000`
             } else {
                 exhaustiveCheck(request.name)
             }

--- a/src/background.js
+++ b/src/background.js
@@ -37,6 +37,7 @@ new OptionsSync().define({
         mergeCommitMessageEnabled: false,
         mergeCommitMessageUrl: null,
         pullrequestCommitAmount: true,
+        totalLinesChanged: true,
         showCommentsCheckbox: true,
         defaultMergeStrategy: 'none',
         autocollapsePaths: [

--- a/src/main.js
+++ b/src/main.js
@@ -37,6 +37,7 @@ import setStickyHeader from './sticky-header'
 import setLineLengthLimit from './limit-line-length'
 import setCompactPRFileTree from './compact-pull-request-file-tree'
 import collapsePullRequestSideMenus from './collapse-pull-request-side-menus'
+import totalLinesChanged from './total-lines-changed'
 
 import observeForWordDiffs from './observe-for-word-diffs'
 
@@ -286,6 +287,10 @@ function pullrequestRelatedFeaturesNew(config) {
 
     if (config.compactFileTree) {
         setCompactPRFileTree()
+    }
+
+    if (config.totalLinesChanged) {
+        totalLinesChanged(window.location.href)
     }
 
     if (config.syntaxHighlight) {

--- a/src/options.html
+++ b/src/options.html
@@ -85,8 +85,8 @@
         <br />
 
         <label>
-            <input type="checkbox" name="ignoreWhitespace" /> Set "Ignore 
-            whitespace" ON by default in the Old PR Experience 
+            <input type="checkbox" name="ignoreWhitespace" /> Set "Ignore
+            whitespace" ON by default in the Old PR Experience
             (already natively supported in the New PR experience)
         </label>
         <br />
@@ -141,6 +141,13 @@
             <input type="checkbox" name="addSidebarCounters" /> Add counters
             to the "Branches" and "Pull requests" links in the navigation
             sidebar menu.
+        </label>
+        <br />
+        <br />
+
+        <label>
+            <input type="checkbox" name="totalLinesChanged" /> Add total
+            lines added and removed to the files tab.
         </label>
         <br />
         <br />

--- a/src/pullrequest-commit-amount/pullrequest-commit-amount.js
+++ b/src/pullrequest-commit-amount/pullrequest-commit-amount.js
@@ -14,9 +14,11 @@ export default async function pullrequestCommitAmount() {
     const pullrequestCommits = await api.getPullrequestCommits(prId)
 
     // eslint-disable-next-line eqeqeq, no-eq-null
-    if (pullrequestCommits && pullrequestCommits.size != null) {
+    if (pullrequestCommits && pullrequestCommits.pagelen != null) {
         const badge = (
-            <span class="__rbb-commit-ammount">{pullrequestCommits.size}</span>
+            <span class="__rbb-commit-ammount">
+                {pullrequestCommits.pagelen}
+            </span>
         )
         const commitsLink: HTMLElement = (document.getElementById(
             'pr-menu-commits'

--- a/src/pullrequest-commit-amount/pullrequest-commit-amount.spec.js
+++ b/src/pullrequest-commit-amount/pullrequest-commit-amount.spec.js
@@ -20,7 +20,7 @@ const mockFetchWithSuccessfulResponse = () => {
     global.chrome = {
         runtime: {
             sendMessage: (data, cb) => {
-                cb({ size: 1 })
+                cb({ pagelen: 1 })
             },
         },
     }

--- a/src/total-lines-changed/index.js
+++ b/src/total-lines-changed/index.js
@@ -1,0 +1,2 @@
+// @flow
+export { default } from './total-lines-changed'

--- a/src/total-lines-changed/total-lines-changed.css
+++ b/src/total-lines-changed/total-lines-changed.css
@@ -1,0 +1,21 @@
+.__rbb-total-lines-added,
+.__rbb-total-lines-removed {
+    font-size: 0.857143em;
+    font-style: inherit;
+    line-height: 1.33333;
+    font-weight: 600;
+    margin-top: 0;
+    padding: 3px 4px;
+}
+
+.__rbb-total-lines-added {
+    background-color: rgb(227, 252, 239);
+    color: rgb(0, 102, 68);
+    border-radius: 3px 0 0 3px;
+}
+
+.__rbb-total-lines-removed {
+    background-color: rgb(255, 235, 230);
+    color: rgb(191, 38, 0);
+    border-radius: 0 3px 3px 0;
+}

--- a/src/total-lines-changed/total-lines-changed.css
+++ b/src/total-lines-changed/total-lines-changed.css
@@ -1,5 +1,6 @@
 .__rbb-total-lines-added,
-.__rbb-total-lines-removed {
+.__rbb-total-lines-removed,
+[data-testid="sidebar-tab-files"] > span:nth-child(2) {
     font-size: 0.857143em;
     font-style: inherit;
     line-height: 1.33333;
@@ -8,10 +9,14 @@
     padding: 3px 4px;
 }
 
+[data-testid="sidebar-tab-files"] > span:nth-child(2) {
+    border-radius: 3px 0 0 3px;
+}
+
+
 .__rbb-total-lines-added {
     background-color: rgb(227, 252, 239);
     color: rgb(0, 102, 68);
-    border-radius: 3px 0 0 3px;
 }
 
 .__rbb-total-lines-removed {

--- a/src/total-lines-changed/total-lines-changed.js
+++ b/src/total-lines-changed/total-lines-changed.js
@@ -12,7 +12,8 @@ const FILES_TAB_SELECTOR = '[data-testid="sidebar-tab-files"]'
 function toReadableNumber(num: number): string {
     if (num > 1000000) {
         return String(Math.round(num / 1000000)) + 'M'
-    } else if (num > 1000) {
+    }
+    if (num > 1000) {
         return String(Math.round(num / 1000)) + 'K'
     }
     return String(num)
@@ -65,9 +66,7 @@ function handleDiffStats(diffStats) {
 }
 
 export default async function totalLinesChanged(url: string) {
-    let filesTab: HTMLElement | null = await elementReady(
-        `${FILES_TAB_SELECTOR} > span:nth-child(2)`
-    )
+    await elementReady(`${FILES_TAB_SELECTOR} > span:nth-child(2)`)
 
     const matches = url.match(/\/pull-requests\/(\d+)/)
     const prId: string | typeof undefined = (matches || [])[1]

--- a/src/total-lines-changed/total-lines-changed.js
+++ b/src/total-lines-changed/total-lines-changed.js
@@ -9,8 +9,15 @@ import './total-lines-changed.css'
 
 const FILES_TAB_SELECTOR = '[data-testid="sidebar-tab-files"]'
 
-let totalAdded: number
-let totalRemoved: number
+function toReadableNumber(num: number): string {
+    if (num > 1000000) {
+        return Math.round(num / 1000000) + 'M'
+    } else if (num > 1000) {
+        return Math.round(num / 1000) + 'K'
+    } else {
+        return num
+    }
+}
 
 export default async function totalLinesChanged(url) {
     let filesTab: HTMLElement = await elementReady(
@@ -38,30 +45,42 @@ export default async function totalLinesChanged(url) {
             const diffStats = await api.getPullrequestFiles(prId, hash1, hash2)
 
             if (diffStats && diffStats.size) {
-                totalAdded = diffStats.values
-                    .map(val => val.lines_added)
-                    .reduce((partialSum, a) => partialSum + a, 0)
-                totalRemoved = diffStats.values
-                    .map(val => val.lines_removed)
-                    .reduce((partialSum, a) => partialSum + a, 0)
-                const linesAddedBadge = (
-                    <span class="__rbb-total-lines-added">+{totalAdded}</span>
-                )
-                const linesRemovedBadge = (
-                    <span class="__rbb-total-lines-removed">
-                        -{totalRemoved}
-                    </span>
-                )
-                // Refetch since the element could have been re-rendered in the meantime
-                filesTab = document.querySelector(FILES_TAB_SELECTOR)
-                const filesCounter = document.querySelector(
-                    `${FILES_TAB_SELECTOR} > span:nth-child(2)`
-                )
-                filesTab.insertBefore(
-                    linesRemovedBadge,
-                    filesCounter.nextSibling
-                )
-                filesTab.insertBefore(linesAddedBadge, filesCounter.nextSibling)
+                if (diffStats.size < 1000) {
+                    const totalAdded: number = diffStats.values
+                        .map(val => val.lines_added)
+                        .reduce((partialSum, a) => partialSum + a, 0)
+                    const totalRemoved: number = diffStats.values
+                        .map(val => val.lines_removed)
+                        .reduce((partialSum, a) => partialSum + a, 0)
+
+                    const linesAddedBadge = (
+                        <span class="__rbb-total-lines-added">
+                            +{toReadableNumber(totalAdded)}
+                        </span>
+                    )
+                    const linesRemovedBadge = (
+                        <span class="__rbb-total-lines-removed">
+                            -{toReadableNumber(totalRemoved)}
+                        </span>
+                    )
+                    // Refetch since the element could have been re-rendered in the meantime
+                    filesTab = document.querySelector(FILES_TAB_SELECTOR)
+                    const filesCounter = document.querySelector(
+                        `${FILES_TAB_SELECTOR} > span:nth-child(2)`
+                    )
+                    filesTab.insertBefore(
+                        linesRemovedBadge,
+                        filesCounter.nextSibling
+                    )
+                    filesTab.insertBefore(
+                        linesAddedBadge,
+                        filesCounter.nextSibling
+                    )
+                } else {
+                    console.warn(
+                        'More than a 1000 files changed, skipping total calculation'
+                    )
+                }
             } else {
                 console.warn('There seem to be no changed files')
             }

--- a/src/total-lines-changed/total-lines-changed.js
+++ b/src/total-lines-changed/total-lines-changed.js
@@ -14,7 +14,7 @@ let totalRemoved: number
 
 export default async function totalLinesChanged(url) {
     let filesTab: HTMLElement = await elementReady(
-        `${FILES_TAB_SELECTOR} > span + span`
+        `${FILES_TAB_SELECTOR} > span:nth-child(2)`
     )
 
     const matches = url.match(/\/pull-requests\/(\d+)/)
@@ -54,8 +54,14 @@ export default async function totalLinesChanged(url) {
                 )
                 // Refetch since the element could have been re-rendered in the meantime
                 filesTab = document.querySelector(FILES_TAB_SELECTOR)
-                filesTab.appendChild(linesAddedBadge)
-                filesTab.appendChild(linesRemovedBadge)
+                const filesCounter = document.querySelector(
+                    `${FILES_TAB_SELECTOR} > span:nth-child(2)`
+                )
+                filesTab.insertBefore(
+                    linesRemovedBadge,
+                    filesCounter.nextSibling
+                )
+                filesTab.insertBefore(linesAddedBadge, filesCounter.nextSibling)
             } else {
                 console.warn('There seem to be no changed files')
             }

--- a/src/total-lines-changed/total-lines-changed.js
+++ b/src/total-lines-changed/total-lines-changed.js
@@ -1,0 +1,70 @@
+// @flow
+// @jsx h
+
+import { h } from 'dom-chef'
+import elementReady from 'element-ready'
+import api from '../api'
+
+import './total-lines-changed.css'
+
+const FILES_TAB_SELECTOR = '[data-testid="sidebar-tab-files"]'
+
+let totalAdded: number
+let totalRemoved: number
+
+export default async function totalLinesChanged(url) {
+    let filesTab: HTMLElement = await elementReady(
+        `${FILES_TAB_SELECTOR} > span + span`
+    )
+
+    const matches = url.match(/\/pull-requests\/(\d+)/)
+    const prId = matches[1]
+
+    if (prId) {
+        const commits = await api.getPullrequestCommits(prId)
+        const activity = await api.getPullrequestActivity(prId)
+
+        const hash1 = commits.values[0].hash
+        const hash2 = (
+            (
+                (
+                    (activity.values.find(value => Boolean(value.update)) || {})
+                        .update || {}
+                ).destination || {}
+            ).commit || {}
+        ).hash
+
+        if (hash1 && hash2) {
+            const diffStats = await api.getPullrequestFiles(prId, hash1, hash2)
+
+            if (diffStats && diffStats.size) {
+                totalAdded = diffStats.values
+                    .map(val => val.lines_added)
+                    .reduce((partialSum, a) => partialSum + a, 0)
+                totalRemoved = diffStats.values
+                    .map(val => val.lines_removed)
+                    .reduce((partialSum, a) => partialSum + a, 0)
+                const linesAddedBadge = (
+                    <span class="__rbb-total-lines-added">+{totalAdded}</span>
+                )
+                const linesRemovedBadge = (
+                    <span class="__rbb-total-lines-removed">
+                        -{totalRemoved}
+                    </span>
+                )
+                // Refetch since the element could have been re-rendered in the meantime
+                filesTab = document.querySelector(FILES_TAB_SELECTOR)
+                filesTab.appendChild(linesAddedBadge)
+                filesTab.appendChild(linesRemovedBadge)
+            } else {
+                console.warn('There seem to be no changed files')
+            }
+        } else {
+            console.warn('Could not find hashes to fetch file diffs')
+        }
+    } else {
+        console.warn('Could not find pull request id')
+    }
+
+    return filesTab
+}

--- a/src/total-lines-changed/total-lines-changed.js
+++ b/src/total-lines-changed/total-lines-changed.js
@@ -40,7 +40,7 @@ function handleDiffStats(diffStats) {
                 </span>
             )
             // Refetch since the element could have been re-rendered in the meantime
-            const filesTab: HTMLElement | nullfilesTab = document.querySelector(
+            const filesTab: HTMLElement | null = document.querySelector(
                 FILES_TAB_SELECTOR
             )
             const filesCounter = document.querySelector(

--- a/src/total-lines-changed/total-lines-changed.js
+++ b/src/total-lines-changed/total-lines-changed.js
@@ -14,8 +14,53 @@ function toReadableNumber(num: number): string {
         return String(Math.round(num / 1000000)) + 'M'
     } else if (num > 1000) {
         return String(Math.round(num / 1000)) + 'K'
+    }
+    return String(num)
+}
+
+function handleDiffStats(diffStats) {
+    if (diffStats && diffStats.size) {
+        if (diffStats.size < 1000) {
+            const totalAdded: number = diffStats.values
+                .map(val => val.lines_added)
+                .reduce((partialSum, a) => partialSum + a, 0)
+            const totalRemoved: number = diffStats.values
+                .map(val => val.lines_removed)
+                .reduce((partialSum, a) => partialSum + a, 0)
+
+            const linesAddedBadge = (
+                <span class="__rbb-total-lines-added">
+                    +{toReadableNumber(totalAdded)}
+                </span>
+            )
+            const linesRemovedBadge = (
+                <span class="__rbb-total-lines-removed">
+                    -{toReadableNumber(totalRemoved)}
+                </span>
+            )
+            // Refetch since the element could have been re-rendered in the meantime
+            const filesTab: HTMLElement | nullfilesTab = document.querySelector(
+                FILES_TAB_SELECTOR
+            )
+            const filesCounter = document.querySelector(
+                `${FILES_TAB_SELECTOR} > span:nth-child(2)`
+            )
+            if (filesTab && filesCounter) {
+                filesTab.insertBefore(
+                    linesRemovedBadge,
+                    filesCounter.nextSibling
+                )
+                filesTab.insertBefore(linesAddedBadge, filesCounter.nextSibling)
+            } else {
+                console.warn('Failed to find files tab counter')
+            }
+        } else {
+            console.warn(
+                'More than a 1000 files changed, skipping total calculation'
+            )
+        }
     } else {
-        return String(num)
+        console.warn('There seem to be no changed files')
     }
 }
 
@@ -46,51 +91,7 @@ export default async function totalLinesChanged(url: string) {
 
         if (hash1 && hash2) {
             const diffStats = await api.getPullrequestFiles(prId, hash1, hash2)
-
-            if (diffStats && diffStats.size) {
-                if (diffStats.size < 1000) {
-                    const totalAdded: number = diffStats.values
-                        .map(val => val.lines_added)
-                        .reduce((partialSum, a) => partialSum + a, 0)
-                    const totalRemoved: number = diffStats.values
-                        .map(val => val.lines_removed)
-                        .reduce((partialSum, a) => partialSum + a, 0)
-
-                    const linesAddedBadge = (
-                        <span class="__rbb-total-lines-added">
-                            +{toReadableNumber(totalAdded)}
-                        </span>
-                    )
-                    const linesRemovedBadge = (
-                        <span class="__rbb-total-lines-removed">
-                            -{toReadableNumber(totalRemoved)}
-                        </span>
-                    )
-                    // Refetch since the element could have been re-rendered in the meantime
-                    filesTab = document.querySelector(FILES_TAB_SELECTOR)
-                    const filesCounter = document.querySelector(
-                        `${FILES_TAB_SELECTOR} > span:nth-child(2)`
-                    )
-                    if (filesTab && filesCounter) {
-                        filesTab.insertBefore(
-                            linesRemovedBadge,
-                            filesCounter.nextSibling
-                        )
-                        filesTab.insertBefore(
-                            linesAddedBadge,
-                            filesCounter.nextSibling
-                        )
-                    } else {
-                        console.warn('Failed to find files tab counter')
-                    }
-                } else {
-                    console.warn(
-                        'More than a 1000 files changed, skipping total calculation'
-                    )
-                }
-            } else {
-                console.warn('There seem to be no changed files')
-            }
+            handleDiffStats(diffStats)
         } else {
             console.warn('Could not find hashes to fetch file diffs')
         }
@@ -98,5 +99,5 @@ export default async function totalLinesChanged(url: string) {
         console.warn('Could not find pull request id')
     }
 
-    return filesTab
+    return document.querySelector(FILES_TAB_SELECTOR)
 }

--- a/src/total-lines-changed/total-lines-changed.spec.js
+++ b/src/total-lines-changed/total-lines-changed.spec.js
@@ -1,0 +1,83 @@
+import test from 'ava'
+import { h } from 'dom-chef'
+import '../../test/setup-jsdom'
+import { addApiTokenMetadata } from '../../test/test-utils'
+
+import totalLinesChanged from '.'
+
+const responses = [
+    // Commits response
+    {
+        size: 1,
+        values: [
+            {
+                hash: '123',
+            },
+        ],
+    },
+
+    // Activity response
+    {
+        size: 1,
+        values: [
+            {
+                update: {
+                    destination: {
+                        commit: {
+                            hash: '456',
+                        },
+                    },
+                },
+            },
+        ],
+    },
+
+    // DiffStats response
+    {
+        size: 1,
+        values: [
+            /* eslint-disable camelcase */
+            { lines_added: 4, lines_removed: 3 },
+            /* eslint-disable camelcase */
+            { lines_added: 16, lines_removed: 2 },
+        ],
+    },
+]
+
+const mockApiResponse = () => {
+    global.chrome = {
+        runtime: {
+            sendMessage: (data, cb) => {
+                cb(responses.shift())
+            },
+        },
+    }
+}
+
+test('should insert total lines added and removed into files tab', async t => {
+    addApiTokenMetadata()
+    mockApiResponse()
+
+    const node = (
+        <div data-testid="sidebar-tab-files">
+            <span class="css-7apn2c eask4t">Files</span>
+            <span class="css-1cgkhv4">21</span>
+        </div>
+    )
+    document.body.appendChild(node)
+
+    const expected = (
+        <div data-testid="sidebar-tab-files">
+            <span class="css-7apn2c eask4t">Files</span>
+            <span class="css-1cgkhv4">21</span>
+            <span class="__rbb-total-lines-added">+20</span>
+            <span class="__rbb-total-lines-removed">-5</span>
+        </div>
+    )
+
+    const actual = await totalLinesChanged(
+        'https://bitbucket.org/username/repo/pull-requests/123'
+    )
+
+    t.is(actual.outerHTML, expected.outerHTML)
+})


### PR DESCRIPTION
This PR adds 2 counters in the files tab header in the right sidebar.
These counters show the total lines added and the total lines removed in the pull request.

![image](https://user-images.githubusercontent.com/1710840/135920358-b9d0b758-c325-466c-984e-ad9e1a61399a.png)

Also correctly adds the counters if there are merge conflicts in the PR:
![image](https://user-images.githubusercontent.com/1710840/135920401-4f2d206e-3046-49cd-851a-ae83d6a6dc62.png)

-   [x] I tested the changes in this pull request myself
-   [x] I added Automated Tests when applicable
-   [x] I added an Option to enable / disable this feature
-   [x] I updated the README.md, with pictures if necessary


