### PR TITLE
feat(pr-template): show commits below template description

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -33,6 +33,7 @@ new OptionsSync().define({
         augmentPrEntry: true,
         comparePagePullRequest: true,
         prTemplateEnabled: true,
+        prTemplateCommits: true,
         prTemplateUrl: null,
         mergeCommitMessageEnabled: false,
         mergeCommitMessageUrl: null,

--- a/src/main.js
+++ b/src/main.js
@@ -90,7 +90,10 @@ function init(config) {
         pullrequestListRelatedFeatures(config)
     } else if (isCreatePullRequestURL()) {
         if (config.prTemplateEnabled) {
-            insertPullrequestTemplate(config.prTemplateUrl)
+            insertPullrequestTemplate(
+                config.prTemplateUrl,
+                config.prTemplateCommits
+            )
         }
 
         if (config.closeAnchorBranch) {

--- a/src/options.html
+++ b/src/options.html
@@ -233,6 +233,12 @@
         </label>
         <br />
         <br />
+        <label>
+            <input type="checkbox" name="prTemplateCommits" />
+            PR Commits at the end of template
+        </label>
+        <br />
+        <br />
 
         <label>
             <input type="checkbox" name="mergeCommitMessageEnabled" /> Use a

--- a/src/options.html
+++ b/src/options.html
@@ -235,7 +235,7 @@
         <br />
         <label>
             <input type="checkbox" name="prTemplateCommits" />
-            PR Commits at the end of template
+            Add commit list after the PR template when creating a PR
         </label>
         <br />
         <br />

--- a/src/pullrequest-template/pullrequest-template.js
+++ b/src/pullrequest-template/pullrequest-template.js
@@ -6,7 +6,8 @@ import { getRepoURL } from '../page-detect'
 import { getFirstFileContents, getMainBranch } from '../utils'
 
 export default async function fetchAndInsertPullrequestTemplate(
-    externalUrl: string
+    externalUrl: string,
+    prTemplateCommits: boolean
 ) {
     const pullrequestTemplateUrls = getPullrequestTemplateUrls()
 
@@ -16,7 +17,7 @@ export default async function fetchAndInsertPullrequestTemplate(
     )
 
     if (template) {
-        insertPullrequestTemplate(template)
+        insertPullrequestTemplate(template, prTemplateCommits)
     }
 }
 
@@ -35,7 +36,10 @@ export function getPullrequestTemplateUrls() {
     return pullrequestTemplateUrls
 }
 
-export async function insertPullrequestTemplate(template: string) {
+export async function insertPullrequestTemplate(
+    template: string,
+    prTemplateCommits: boolean
+) {
     const defaultEditor = elementReady('textarea[id="id_description"]')
     const atlassianEditor = elementReady(
         '#ak_editor_description div[contenteditable="true"]'
@@ -48,7 +52,10 @@ export async function insertPullrequestTemplate(template: string) {
     if (editor instanceof HTMLTextAreaElement) {
         editor.value = template
     } else if (editor instanceof HTMLDivElement) {
-        const html = marked(template)
+        let html = marked(template)
+        if (prTemplateCommits) {
+            html += editor.innerHTML
+        }
         editor.innerHTML = html
     } else {
         console.warn(

--- a/src/pullrequest-template/pullrequest-template.js
+++ b/src/pullrequest-template/pullrequest-template.js
@@ -50,7 +50,11 @@ export async function insertPullrequestTemplate(
     editorPromises.forEach(p => requestAnimationFrame(() => p.cancel()))
 
     if (editor instanceof HTMLTextAreaElement) {
-        editor.value = template
+        if (prTemplateCommits) {
+            editor.value = template + editor.value
+        } else {
+            editor.value = template
+        }
     } else if (editor instanceof HTMLDivElement) {
         let html = marked(template)
         if (prTemplateCommits) {

--- a/src/pullrequest-template/pullrequest-template.spec.js
+++ b/src/pullrequest-template/pullrequest-template.spec.js
@@ -97,9 +97,49 @@ test.serial(
 )
 
 test.serial(
-    'should insert pull request template in Atlassian editor',
+    'should insert pull request template in Atlassian editor with commits',
     async t => {
         setDocumentBodyAttributes()
+        const prCommits = true
+
+        const templateContents = 'pull request template contents'
+
+        const atlassianEditor = (
+            <ak-editor-bitbucket id="ak_editor_description">
+                <div contenteditable="true">
+                    <ul class="ak-ul" data-indent-level="1">
+                        <li>
+                            <p>feat: example commit in list</p>
+                        </li>
+                        <li>
+                            <p>feat: second commit example in list</p>
+                        </li>
+                    </ul>
+                </div>
+            </ak-editor-bitbucket>
+        )
+        const editorCurrentCommits = atlassianEditor.firstChild.innerHTML
+
+        delay(100).then(() => document.body.appendChild(atlassianEditor))
+
+        await insertPullrequestTemplate(templateContents, prCommits)
+
+        let richTemplateContents = marked(templateContents)
+        if (prCommits) {
+            richTemplateContents += editorCurrentCommits
+        }
+        t.is(atlassianEditor.firstChild.innerHTML, richTemplateContents)
+
+        cleanDocumentBody()
+        await delay(16)
+    }
+)
+
+test.serial(
+    'should insert pull request template in Atlassian editor without commits',
+    async t => {
+        setDocumentBodyAttributes()
+        const prCommits = false
 
         const templateContents = 'pull request template contents'
 
@@ -110,7 +150,7 @@ test.serial(
         )
         delay(100).then(() => document.body.appendChild(atlassianEditor))
 
-        await insertPullrequestTemplate(templateContents)
+        await insertPullrequestTemplate(templateContents, prCommits)
 
         const richTemplateContents = marked(templateContents)
         t.is(atlassianEditor.firstChild.innerHTML, richTemplateContents)


### PR DESCRIPTION
This feature add the posibility to leave commits list when using a template for pull request description.
Tell me any change you think is appropriate

-   [X] I tested the changes in this pull request myself
-   [X] I added Automated Tests when applicable
-   [X] I added an Option to enable / disable this feature
-   [ ] I updated the README.md, with pictures if necessary
