### PR TITLE
rudimentary ignore-pull-request

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -197,14 +197,14 @@ function codeReviewFeatures(config) {
                         .match(/pull-requests\/(?<prId>\d+)/)[1]
                 )
                 let ignoredPrs = localStorage.getItem('ignoredPrs')
-                if (ignoredPr) {
+                if (ignoredPrs) {
                     ignoredPrs = JSON.parse(ignoredPrs)
                 } else {
                     ignoredPrs = []
                 }
                 const ignoreKey = ignoredPrs.indexOf(prId)
                 // Todo find a better way to send the message.. also eslint-disable something
-                const fixme = window.alert
+                const fixme = window.alert.bind(window)
                 if (ignoreKey === -1) {
                     ignoredPrs.push(prId)
                     localStorage.setItem(

--- a/src/main.js
+++ b/src/main.js
@@ -130,7 +130,7 @@ function pullrequestListRelatedFeatures(config) {
     config.ignorePullRequests =
         config.ignorePullRequests === undefined
             ? true
-            : config.ignorePullRequests // todo add proper config
+            : config.ignorePullRequests // Todo add proper config
     if (
         !config.ignoreWhitespace &&
         !config.augmentPrEntry &&
@@ -139,12 +139,12 @@ function pullrequestListRelatedFeatures(config) {
         return
     }
     if (config.ignorePullRequests) {
-        // todo: figure out how to run this code after the PRs are loaded, instead of this setInterval hack...
-        setInterval(function() {
+        // Todo: figure out how to run this code after the PRs are loaded, instead of this setInterval hack...
+        setInterval(() => {
             let ignoredPrs = localStorage.getItem('ignoredPrs')
             if (ignoredPrs) {
                 ignoredPrs = JSON.parse(ignoredPrs)
-                $("tr[data-qa*='pull-request-row']").each(function(index, ele) {
+                $("tr[data-qa*='pull-request-row']").each((index, ele) => {
                     const prId = Number(
                         ele
                             .querySelector('a')
@@ -180,27 +180,33 @@ function codeReviewFeatures(config) {
     config.ignorePullRequests =
         config.ignorePullRequests === undefined
             ? true
-            : config.ignorePullRequests // todo add proper config
+            : config.ignorePullRequests // Todo add proper config
     if (config.ignorePullRequests) {
-        // i can't figure out how to execute this *at the right time*, seems bitbucket first creates the entire page
+        // I can't figure out how to execute this *at the right time*, seems bitbucket first creates the entire page
         // then proceed to remove the entire page, then create the entire page again...
         // so i made this setInterval hack that works, but is a waste of cpu cycles
-        setInterval(function() {
+        setInterval(() => {
             if ($('#pull-requests-button').length > 0) {
                 return
             }
-            let pullRequestButton = document.createElement('span')
+            const pullRequestButton = document.createElement('span')
             pullRequestButton.id = 'pull-requests-button'
             pullRequestButton.innerHTML =
                 '<div class="css-z25nd1"><button aria-pressed="false" aria-label="Ignore this pull request" tabindex="0" type="button" class="css-1v2ovpy"><span class="css-j8fq0c"><span class="css-8xpfx5"><span role="presentation" aria-hidden="true" style="--icon-primary-color: white; --icon-secondary-color: var(--ds-surface, #FFFFFF);" class="css-pxzk9z"><svg width="24" height="24" viewBox="0 0 24 24" role="presentation"><g fill-rule="evenodd"><circle fill="currentColor" cx="12" cy="12" r="10"></circle><path d="M9.707 11.293a1 1 0 10-1.414 1.414l2 2a1 1 0 001.414 0l4-4a1 1 0 10-1.414-1.414L11 12.586l-1.293-1.293z" fill="inherit"></path></g></svg></span></span><span class="css-mu6jxl"><span id="ignore-this-pr-inner-span">Ignore this pull request</span></span></span></button></div>'
-            $(pullRequestButton).on('click', function() {
+            $(pullRequestButton).on('click', () => {
                 const prId = Number(
                     document.location
                         .toString()
                         .match(/pull-requests\/(?<prId>\d+)/)[1]
                 )
                 let ignoredPrs = localStorage.getItem('ignoredPrs')
-                if (!ignoredPrs) {
+                // avoid annoying linter "no negated expression" error...
+                if (
+                    ignoredPrs === null ||
+                    ignoredPrs === undefined ||
+                    ignoredPrs === false ||
+                    ignoredPrs === ''
+                ) {
                     ignoredPrs = []
                 } else {
                     ignoredPrs = JSON.parse(ignoredPrs)

--- a/src/main.js
+++ b/src/main.js
@@ -150,11 +150,8 @@ function pullrequestListRelatedFeatures(config) {
                             .querySelector('a')
                             .href.match(/pull-requests\/(?<prId>\d+)/)[1]
                     )
-                    if (ignoredPrs.indexOf(prId) !== -1) {
-                        ele.style['text-decoration'] = 'line-through'
-                    } else {
-                        ele.style['text-decoration'] = ''
-                    }
+                    ele.style['text-decoration'] =
+                        ignoredPrs.indexOf(prId) === -1 ? '' : 'line-through'
                 })
             }
         }, 1000)
@@ -200,32 +197,28 @@ function codeReviewFeatures(config) {
                         .match(/pull-requests\/(?<prId>\d+)/)[1]
                 )
                 let ignoredPrs = localStorage.getItem('ignoredPrs')
-                // avoid annoying linter "no negated expression" error...
-                if (
-                    ignoredPrs === null ||
-                    ignoredPrs === undefined ||
-                    ignoredPrs === false ||
-                    ignoredPrs === ''
-                ) {
-                    ignoredPrs = []
-                } else {
+                if (ignoredPr) {
                     ignoredPrs = JSON.parse(ignoredPrs)
+                } else {
+                    ignoredPrs = []
                 }
                 const ignoreKey = ignoredPrs.indexOf(prId)
+                // Todo find a better way to send the message.. also eslint-disable something
+                const fixme = window.alert
                 if (ignoreKey === -1) {
                     ignoredPrs.push(prId)
                     localStorage.setItem(
                         'ignoredPrs',
                         JSON.stringify(ignoredPrs)
                     )
-                    alert('added to ignoredPrs')
+                    fixme('added to ignoredPrs')
                 } else {
                     ignoredPrs.splice(ignoreKey, 1)
                     localStorage.setItem(
                         'ignoredPrs',
                         JSON.stringify(ignoredPrs)
                     )
-                    alert('removed from ignoredPrs')
+                    fixme('removed from ignoredPrs')
                 }
             })
             $('.css-vxcmzt:first').prepend(pullRequestButton)

--- a/src/main.js
+++ b/src/main.js
@@ -194,7 +194,7 @@ function codeReviewFeatures(config) {
             const pullRequestButton = document.createElement('span')
             pullRequestButton.id = 'pull-requests-button'
             pullRequestButton.innerHTML =
-                '<div class="css-z25nd1"><button aria-pressed="false" aria-label="Ignore this pull request" tabindex="0" type="button" class="css-1v2ovpy"><span class="css-j8fq0c"><span class="css-8xpfx5"><span role="presentation" aria-hidden="true" style="--icon-primary-color: white; --icon-secondary-color: var(--ds-surface, #FFFFFF);" class="css-pxzk9z"><svg width="24" height="24" viewBox="0 0 24 24" role="presentation"><g fill-rule="evenodd"><circle fill="currentColor" cx="12" cy="12" r="10"></circle><path d="M9.707 11.293a1 1 0 10-1.414 1.414l2 2a1 1 0 001.414 0l4-4a1 1 0 10-1.414-1.414L11 12.586l-1.293-1.293z" fill="inherit"></path></g></svg></span></span><span class="css-mu6jxl"><span id="ignore-this-pr-inner-span">Ignore this pull request</span></span></span></button></div>'
+                '<div class="css-z25nd1"><button aria-pressed="false" aria-label="Ignore this pull request" tabindex="0" type="button" class="css-1v2ovpy"><span class="css-j8fq0c"><span class="css-8xpfx5"><span role="presentation" aria-hidden="true" style="--icon-primary-color: white; --icon-secondary-color: var(--ds-surface, #FFFFFF);" class="css-snhnyn"><svg width="24" height="24" viewBox="0 0 24 24" role="presentation"><g fill-rule="evenodd"><circle fill="currentColor" cx="12" cy="12" r="10"></circle><path d="M9.707 11.293a1 1 0 10-1.414 1.414l2 2a1 1 0 001.414 0l4-4a1 1 0 10-1.414-1.414L11 12.586l-1.293-1.293z" fill="inherit"></path></g></svg></span></span><span class="css-mu6jxl"><span id="ignore-this-pr-inner-span">Ignore this pull request</span></span></span></button></div>'
             $(pullRequestButton).on('click', () => {
                 const prId = Number(
                     document.location
@@ -226,7 +226,7 @@ function codeReviewFeatures(config) {
                     fixme('removed from ignoredPrs')
                 }
             })
-            $('.css-vxcmzt:first').prepend(pullRequestButton)
+            $('.css-a49m9p:first').prepend(pullRequestButton)
         }, 1000)
     }
 

--- a/src/main.js
+++ b/src/main.js
@@ -144,17 +144,22 @@ function pullrequestListRelatedFeatures(config) {
             let ignoredPrs = localStorage.getItem('ignoredPrs')
             if (ignoredPrs) {
                 ignoredPrs = JSON.parse(ignoredPrs)
-                $("tr[data-qa*='pull-request-row']").each((index, ele) => {
-                    const prId = Number(
-                        ele
-                            .querySelector('a')
-                            .href.match(/pull-requests\/(?<prId>\d+)/)[1]
-                    )
-                    ele.style['text-decoration'] =
-                        ignoredPrs.indexOf(prId) === -1 ? '' : 'line-through'
-                })
+                document
+                    .querySelectorAll("tr[data-qa*='pull-request-row']")
+                    .forEach(ele => {
+                        const prId = Number(
+                            ele
+                                .querySelector('a')
+                                .getAttribute('href')
+                                .match(/pull-requests\/(?<prId>\d+)/)[1]
+                        )
+                        ele.style['text-decoration'] =
+                            ignoredPrs.indexOf(prId) === -1
+                                ? ''
+                                : 'line-through'
+                    })
             }
-        }, 1000)
+        }, 3000)
     }
 
     // eslint-disable-next-line no-new


### PR DESCRIPTION
rudimentary ignore-pull-request, similar to what i requested in #430 with the same rationale:
at my job, on the pull-requests page, there are lots of pull requests that are irrelevant to me, relating to code I am not qualified to, or not interested in, or already have approved but has not been merged yet, and i wish i could hide them, or strikethrough-text them. with this, i finally can. screenshot: 
![image](https://user-images.githubusercontent.com/1874996/175759481-27eb41c5-6874-44f1-a428-d195a7bcbab8.png)

- this code is *far* from perfect though, on the individual PR page, it seems bitbucket is creating the whole page, then deleting the whole page, then creating it again.. i couldn't figure out how to properly inject the button afte re-creation, so i setteled on a setInterval hack, which works, but isn't ideal. also i'm not sure how to split up the logic to different files, i just jammed all the logic into main.js, i'm guessing you want those split separate files somewhere/somehow? also i haven't figured out how to properly create a new config option, so this feature is just kindof always-on right now

<!--
    Check those that apply, and delete the ones that don't
-->

-   [x] I tested the changes in this pull request myself
-   [ ] I added Automated Tests when applicable
-   [ ] I added an Option to enable / disable this feature
-   [ ] I updated the README.md, with pictures if necessary
